### PR TITLE
[REFACTOR] AuthController 문자열 리터럴 상수 변환 및 PropertyKey 로직 메서드로 추출

### DIFF
--- a/src/main/java/econo/buddybridge/auth/controller/AuthController.java
+++ b/src/main/java/econo/buddybridge/auth/controller/AuthController.java
@@ -38,7 +38,7 @@ public class AuthController {
     }
 
     @PostMapping("/api/oauth/login")
-    public ApiResponse<?> login(@RequestBody KakaoLoginParams params, final HttpServletRequest request) {
+    public ApiResponse<CustomBody<MemberDto>> login(@RequestBody KakaoLoginParams params, HttpServletRequest request) {
         HttpSession session = request.getSession(false);
 
         MemberDto memberDto;
@@ -59,14 +59,14 @@ public class AuthController {
     }
 
     private MemberDto handleExistingSession(HttpSession session) {
-        String memberIdStr = String.valueOf(session.getAttribute("memberId"));
-        if (memberIdStr == null || memberIdStr.isEmpty()) {
+        Object memberIdObj = session.getAttribute("memberId");
+        if (memberIdObj == null || memberIdObj.toString().isEmpty()) {
             throw new IllegalArgumentException("세션에 유효한 memberId가 없습니다.");
         }
 
         Long memberId;
         try {
-            memberId = Long.parseLong(memberIdStr);
+            memberId = Long.parseLong(memberIdObj.toString());
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("세션의 memberId 형식이 잘못되었습니다.", e);
         }


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

- AuthController 내부 "Bearer " 리터럴을 TOKEN_PREFIX 상수로 저장 후 사용
- getUserInfo 내부 PropertyKey를 추출하는 로직을 함수로 추출

## 참고 사항

## 관련 이슈

close #18 

## 체크리스트

- [x] 코드가 제대로 작동하는지 확인
- [x] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [x] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
