### PR TITLE
fix#29: Post Entity Member필드 fetch 타입 EAGER -> LAZY 변환

### DIFF
--- a/src/main/java/econo/buddybridge/post/dto/PostResDto.java
+++ b/src/main/java/econo/buddybridge/post/dto/PostResDto.java
@@ -1,15 +1,16 @@
 package econo.buddybridge.post.dto;
 
-import econo.buddybridge.member.entity.Member;
+import econo.buddybridge.member.dto.MemberDto;
 import econo.buddybridge.post.entity.*;
 import lombok.Builder;
+import econo.buddybridge.post.service.PostService;
 
 import java.time.LocalDateTime;
 
 @Builder
 public record PostResDto(
         Long id,
-        Member author,
+        MemberDto author,
         String title,
         AssistanceType assistanceType,
 //        Schedule schedule,
@@ -27,7 +28,7 @@ public record PostResDto(
     public PostResDto(Post post) {
         this(
             post.getId(),
-            post.getAuthor(),
+            PostService.toMemberDto(post.getAuthor()),
             post.getTitle(),
             post.getAssistanceType(),
 //            post.getSchedule(),
@@ -43,4 +44,5 @@ public record PostResDto(
             post.getPostStatus()
         );
     }
+
 }

--- a/src/main/java/econo/buddybridge/post/entity/Post.java
+++ b/src/main/java/econo/buddybridge/post/entity/Post.java
@@ -23,7 +23,7 @@ public class Post extends BaseEntity {
     private Long id;
 
 //    @ManyToOne(cascade = CascadeType.REMOVE)
-    @ManyToOne()
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="author_id")
     private Member author;
 

--- a/src/main/java/econo/buddybridge/post/repository/PostRepository.java
+++ b/src/main/java/econo/buddybridge/post/repository/PostRepository.java
@@ -2,9 +2,19 @@ package econo.buddybridge.post.repository;
 
 import econo.buddybridge.post.entity.Post;
 import econo.buddybridge.post.entity.PostType;
+import lombok.NonNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    @NonNull
+    @EntityGraph(attributePaths = {"author"})
+    Optional<Post> findById(Long postId);
+
     Page<Post> findByPostType(Pageable pageable, PostType postType);
 }

--- a/src/main/java/econo/buddybridge/post/service/PostService.java
+++ b/src/main/java/econo/buddybridge/post/service/PostService.java
@@ -1,5 +1,6 @@
 package econo.buddybridge.post.service;
 
+import econo.buddybridge.member.dto.MemberDto;
 import econo.buddybridge.member.entity.Member;
 import econo.buddybridge.member.repository.MemberRepository;
 import econo.buddybridge.post.dto.PostReqDto;
@@ -48,6 +49,7 @@ public class PostService {
         } else {
             postPage = postRepository.findAll(pageable);
         }
+
         return postPage.map(PostResDto::new);
     }
 
@@ -76,7 +78,7 @@ public class PostService {
     public PostResDto postToPostRes(Post post){
         return PostResDto.builder()
                 .id(post.getId())
-                .author(post.getAuthor())
+                .author(toMemberDto(post.getAuthor()))
                 .title(post.getTitle())
                 .assistanceType(post.getAssistanceType())
                 .startTime(post.getSchedule().getStartTime())
@@ -118,5 +120,17 @@ public class PostService {
     public Member getAuthor(PostReqDto postReqDto){
         return memberRepository.findById(postReqDto.memberId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+    }
+    public static MemberDto toMemberDto(Member member) {
+        return MemberDto.builder()
+                .memberId(member.getId())
+                .name(member.getName())
+                .nickname(member.getNickname())
+                .profileImageUrl(member.getProfileImageUrl())
+                .email(member.getEmail())
+                .age(member.getAge())
+                .gender(member.getGender())
+                .disabilityType(member.getDisabilityType())
+                .build();
     }
 }


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

기존 Post의 Member 필드 fetch 값을 EAGER에서 LAZY로 변경

## 관련 이슈

close #29 

## 체크리스트

- [X] 코드가 제대로 작동하는지 확인
- [X] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [X] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
