### PR TITLE
[Refactor] : Websocket 사용시 로그인한 사용자 ID 가져오기, 매칭 리스트 조회 로직 JPQL에서 QueryDsl로 변경

### DIFF
--- a/src/main/java/econo/buddybridge/chat/chatmessage/controller/ChatMessageController.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/controller/ChatMessageController.java
@@ -3,6 +3,7 @@ package econo.buddybridge.chat.chatmessage.controller;
 import econo.buddybridge.chat.chatmessage.dto.ChatMessageReqDto;
 import econo.buddybridge.chat.chatmessage.dto.ChatMessageResDto;
 import econo.buddybridge.chat.chatmessage.service.ChatMessageService;
+import econo.buddybridge.utils.session.SessionUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.*;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,17 +22,8 @@ public class ChatMessageController {
             @Payload ChatMessageReqDto chatMessageReqDto,
             @Header ("simpSessionAttributes") Map<String, Object> attributes
     ){
-
-        // TODO: 세션 유틸에 타입유형 검사하는 로직 만들기
-        Long senderId = null;
         Object memberIdObject = attributes.get("memberId");
-        if(memberIdObject instanceof Integer){
-            senderId = ((Integer) memberIdObject).longValue();
-        } else if(memberIdObject instanceof Long){
-            senderId = (Long) memberIdObject;
-        } else{
-            throw new IllegalArgumentException("적절하지 않은 memberId 입니다.");
-        }
+        Long senderId = SessionUtils.validateMemberId(memberIdObject);
         return chatMessageService.save(senderId,chatMessageReqDto,matchingId);
     }
 

--- a/src/main/java/econo/buddybridge/chat/chatmessage/controller/ChatMessageController.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/controller/ChatMessageController.java
@@ -3,42 +3,46 @@ package econo.buddybridge.chat.chatmessage.controller;
 import econo.buddybridge.chat.chatmessage.dto.ChatMessageReqDto;
 import econo.buddybridge.chat.chatmessage.dto.ChatMessageResDto;
 import econo.buddybridge.chat.chatmessage.service.ChatMessageService;
-import econo.buddybridge.utils.api.ApiResponse;
-import econo.buddybridge.utils.api.ApiResponseGenerator;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.messaging.handler.annotation.DestinationVariable;
-import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.handler.annotation.SendTo;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.messaging.handler.annotation.*;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
 public class ChatMessageController {
-
     private final ChatMessageService chatMessageService;
 
     @MessageMapping("/chat/{matching-id}") // 메시지 보내기 // /api/app/chat/{room-id} - pub
     @SendTo("/api/queue/chat/{matching-id}") // 구독 경로 - sub
     public ChatMessageResDto sendMessage(
             @DestinationVariable("matching-id") Long matchingId,
-            @Payload ChatMessageReqDto chatMessageReqDto
-            // HttpServletRequest request
-            ){
-        return chatMessageService.save(chatMessageReqDto,matchingId);
+            @Payload ChatMessageReqDto chatMessageReqDto,
+            @Header ("simpSessionAttributes") Map<String, Object> attributes
+    ){
+
+        // TODO: 세션 유틸에 타입유형 검사하는 로직 만들기
+        Long senderId = null;
+        Object memberIdObject = attributes.get("memberId");
+        if(memberIdObject instanceof Integer){
+            senderId = ((Integer) memberIdObject).longValue();
+        } else if(memberIdObject instanceof Long){
+            senderId = (Long) memberIdObject;
+        } else{
+            throw new IllegalArgumentException("적절하지 않은 memberId 입니다.");
+        }
+        return chatMessageService.save(senderId,chatMessageReqDto,matchingId);
     }
 
     // 마지막 메시지 1개만 받아오기
-    @GetMapping("/api/queue/chat/{matching-id}")
-    public ApiResponse<ApiResponse.CustomBody<ChatMessageResDto>> getMessages(
-            @PathVariable("matching-id") Long matchingId
-    ){
-        ChatMessageResDto resDto = chatMessageService.getLastChatMessage(matchingId);
-        return ApiResponseGenerator.success(resDto, HttpStatus.OK);
-    }
+//    @GetMapping("/api/queue/chat/{matching-id}")
+//    public ApiResponse<ApiResponse.CustomBody<ChatMessageResDto>> getMessages(
+//            @PathVariable("matching-id") Long matchingId
+//    ){
+//        ChatMessageResDto resDto = chatMessageService.getLastChatMessage(matchingId);
+//        return ApiResponseGenerator.success(resDto, HttpStatus.OK);
+//    }
 
     //TODO: 채팅 메시지 삭제(업데이트로 MessageType: DELETE로 변경)
 }

--- a/src/main/java/econo/buddybridge/chat/chatmessage/dto/ChatMessageReqDto.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/dto/ChatMessageReqDto.java
@@ -3,7 +3,6 @@ package econo.buddybridge.chat.chatmessage.dto;
 import econo.buddybridge.chat.chatmessage.entity.MessageType;
 
 public record ChatMessageReqDto(
-        Long senderId, // TODO: 추후 제거 -> 로그인한 사용자에서 추출
         String content,
         MessageType messageType
 ) {

--- a/src/main/java/econo/buddybridge/chat/chatmessage/service/ChatMessageService.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/service/ChatMessageService.java
@@ -20,8 +20,8 @@ public class ChatMessageService {
     private final ChatMessageRepository chatMessageRepository;
 
     @Transactional // 메시지 저장
-    public ChatMessageResDto save(ChatMessageReqDto chatMessageReqDto, Long matchingId){
-        Member sender = memberRepository.findById(chatMessageReqDto.senderId())
+    public ChatMessageResDto save(Long senderId,ChatMessageReqDto chatMessageReqDto, Long matchingId){
+        Member sender = memberRepository.findById(senderId)
                 .orElseThrow(()->new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
         Matching matching = matchingRepository.findById(matchingId)
@@ -38,7 +38,7 @@ public class ChatMessageService {
 
         return ChatMessageResDto.builder()
                 .messageId(chatMessage.getId())
-                .senderId(chatMessageReqDto.senderId()) // senderId 받아오기
+                .senderId(chatMessage.getSender().getId())
                 .content(chatMessageReqDto.content())
                 .messageType(chatMessageReqDto.messageType())
                 .createdAt(chatMessage.getCreatedAt())

--- a/src/main/java/econo/buddybridge/matching/controller/MatchingController.java
+++ b/src/main/java/econo/buddybridge/matching/controller/MatchingController.java
@@ -34,7 +34,7 @@ public class MatchingController {
             @PathVariable("matching-id") Long matchingId,
             @RequestBody MatchingUpdateDto matchingUpdateDto,
             HttpServletRequest request
-            ){
+    ){
         Long memberId = SessionUtils.getMemberId(request);
         Long updatedMatchingId = matchingService.updateMatching(matchingId,matchingUpdateDto,memberId);
         return ApiResponseGenerator.success(updatedMatchingId,HttpStatus.OK);

--- a/src/main/java/econo/buddybridge/matching/repository/MatchingRepository.java
+++ b/src/main/java/econo/buddybridge/matching/repository/MatchingRepository.java
@@ -10,24 +10,5 @@ import org.springframework.data.jpa.repository.Query;
 import java.time.LocalDateTime;
 
 public interface MatchingRepository extends JpaRepository<Matching, Long> {
-    
-    
-    // TODO: queryDSL로 변경 시키기 JOIN 빼버리기
-    // Stream이니깐 Sort로 정렬시키고 LastMessageTime을 기준으로
-    // org.hibernate.NonUniqueResultException: Query did not return a unique result: 5 results were returned
-    @Query("SELECT m FROM Matching m " +
-            "LEFT JOIN ChatMessage cm ON m.id = cm.matching.id " +
-            "WHERE (m.taker.id = :memberId OR m.giver.id = :memberId) " +
-            "GROUP BY m.id " +
-            "ORDER BY MAX(cm.createdAt) DESC")
-    Slice<Matching> findMatchingByTakerIdOrGiverId(@Param("memberId") Long memberId, Pageable pageable);
 
-
-    @Query("SELECT m FROM Matching m " +
-            "LEFT JOIN ChatMessage cm ON m.id = cm.matching.id " +
-            "WHERE (m.taker.id = :memberId OR m.giver.id = :memberId) " +
-            "AND cm.createdAt > :cursor " +
-            "GROUP BY m.id " +
-            "ORDER BY MAX(cm.createdAt) DESC")
-    Slice<Matching> findMatchingByTakerIdOrGiverIdAndIdLessThan(@Param("memberId") Long memberId,@Param("cursor") LocalDateTime cursor, Pageable pageable);
 }

--- a/src/main/java/econo/buddybridge/matching/repository/MatchingRepository.java
+++ b/src/main/java/econo/buddybridge/matching/repository/MatchingRepository.java
@@ -10,7 +10,11 @@ import org.springframework.data.jpa.repository.Query;
 import java.time.LocalDateTime;
 
 public interface MatchingRepository extends JpaRepository<Matching, Long> {
-
+    
+    
+    // TODO: queryDSL로 변경 시키기 JOIN 빼버리기
+    // Stream이니깐 Sort로 정렬시키고 LastMessageTime을 기준으로
+    // org.hibernate.NonUniqueResultException: Query did not return a unique result: 5 results were returned
     @Query("SELECT m FROM Matching m " +
             "LEFT JOIN ChatMessage cm ON m.id = cm.matching.id " +
             "WHERE (m.taker.id = :memberId OR m.giver.id = :memberId) " +

--- a/src/main/java/econo/buddybridge/matching/repository/MatchingRepositoryCustom.java
+++ b/src/main/java/econo/buddybridge/matching/repository/MatchingRepositoryCustom.java
@@ -1,0 +1,15 @@
+package econo.buddybridge.matching.repository;
+
+import econo.buddybridge.matching.entity.Matching;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Repository
+public interface MatchingRepositoryCustom {
+    Slice<Matching> findMatchingByTakerIdOrGiverId(Long memberId, Pageable pageable);
+    Slice<Matching> findMatchingByTakerIdOrGiverIdAndIdLessThan(Long memberId, LocalDateTime cursor, Pageable pageable);
+}

--- a/src/main/java/econo/buddybridge/matching/repository/MatchingRepositoryCustomImpl.java
+++ b/src/main/java/econo/buddybridge/matching/repository/MatchingRepositoryCustomImpl.java
@@ -1,0 +1,78 @@
+package econo.buddybridge.matching.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import econo.buddybridge.chat.chatmessage.entity.QChatMessage;
+import econo.buddybridge.matching.entity.Matching;
+import econo.buddybridge.matching.entity.QMatching;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class MatchingRepositoryCustomImpl implements MatchingRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<Matching> findMatchingByTakerIdOrGiverId(Long memberId, Pageable pageable) {
+        return findMatchingByTakerIdOrGiverIdAndCursor(memberId, null, pageable);
+    }
+
+    @Override
+    public Slice<Matching> findMatchingByTakerIdOrGiverIdAndIdLessThan(Long memberId, LocalDateTime cursor, Pageable pageable) {
+        return findMatchingByTakerIdOrGiverIdAndCursor(memberId, cursor, pageable);
+    }
+
+    private Slice<Matching> findMatchingByTakerIdOrGiverIdAndCursor(Long memberId,LocalDateTime cursor, Pageable pageable) {
+        QMatching matching = QMatching.matching;
+        QChatMessage chatMessage = QChatMessage.chatMessage;
+
+        List<Matching> matchingList = queryFactory.selectFrom(matching)
+                .where(matching.taker.id.eq(memberId).or(matching.giver.id.eq(memberId)))
+                .fetch();
+
+        // 각 Matching에 대해 마지막 ChatMessage의 생성 시간
+        Map<Long, LocalDateTime> latestMessageTimeMap = matchingList.stream()
+                .collect(Collectors.toMap(
+                        Matching::getId,
+                        m -> {
+                            LocalDateTime latestMessageTime = queryFactory.select(chatMessage.createdAt.max())
+                                    .from(chatMessage)
+                                    .where(chatMessage.matching.id.eq(m.getId()))
+                                    .fetchOne();
+                            return latestMessageTime != null ? latestMessageTime : LocalDateTime.MIN;
+                        }
+                ));
+
+        // Matching 리스트를 마지막 메시지의 createdAt을 기준으로 정렬
+        List<Matching> sortedMatchingList = matchingList.stream()
+                .filter(m -> cursor == null || latestMessageTimeMap.get(m.getId()).isAfter(cursor))
+                .sorted((m1, m2) -> {
+                    LocalDateTime time1 = latestMessageTimeMap.get(m1.getId());
+                    LocalDateTime time2 = latestMessageTimeMap.get(m2.getId());
+                    return time2.compareTo(time1); // 내림차순 정렬
+                })
+                .skip(pageable.getOffset()) // page 기반 시 필요
+                .limit(pageable.getPageSize() + 1)
+                .toList();
+
+        return createSlice(sortedMatchingList, pageable);
+    }
+
+    private Slice<Matching> createSlice(List<Matching> matchingList, Pageable pageable){
+        boolean hasNext = matchingList.size() > pageable.getPageSize();
+        if(hasNext){
+            matchingList.remove(matchingList.size() - 1);
+        }
+        return new SliceImpl<>(matchingList,pageable,hasNext);
+    }
+}

--- a/src/main/java/econo/buddybridge/matching/service/MatchingRoomService.java
+++ b/src/main/java/econo/buddybridge/matching/service/MatchingRoomService.java
@@ -9,6 +9,7 @@ import econo.buddybridge.matching.dto.MatchingResDto;
 import econo.buddybridge.matching.dto.ReceiverDto;
 import econo.buddybridge.matching.entity.Matching;
 import econo.buddybridge.matching.repository.MatchingRepository;
+import econo.buddybridge.matching.repository.MatchingRepositoryCustom;
 import econo.buddybridge.member.entity.Member;
 import econo.buddybridge.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,7 @@ public class MatchingRoomService {
     private final MemberRepository memberRepository;
     private final MatchingRepository matchingRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final MatchingRepositoryCustom matchingRepositoryCustom;
 
     // 페이지네이션 적용
     @Transactional
@@ -36,9 +38,9 @@ public class MatchingRoomService {
         Slice<Matching> matchingSlice;
 
         if(cursor == null){
-            matchingSlice = matchingRepository.findMatchingByTakerIdOrGiverId(memberId,pageable);
+            matchingSlice = matchingRepositoryCustom.findMatchingByTakerIdOrGiverId(memberId,pageable);
         } else { // 마지막 채팅 메시지 생성일자 기준 내림차순, cursor 값 이후에 생성된 내용 조회
-            matchingSlice = matchingRepository.findMatchingByTakerIdOrGiverIdAndIdLessThan(memberId,cursor,pageable);
+            matchingSlice = matchingRepositoryCustom.findMatchingByTakerIdOrGiverIdAndIdLessThan(memberId,cursor,pageable);
         }
 
         List<Matching> matchingList = matchingSlice.getContent();

--- a/src/main/java/econo/buddybridge/post/controller/PostController.java
+++ b/src/main/java/econo/buddybridge/post/controller/PostController.java
@@ -45,6 +45,7 @@ public class PostController {
 
     // 단일 게시글 조회
     @GetMapping("/{post-id}")
+    @AllowAnonymous
     public ApiResponse<ApiResponse.CustomBody<PostResDto>> getPost(@PathVariable("post-id") Long postId){
         PostResDto postResDto = postService.findPost(postId);
         return ApiResponseGenerator.success(postResDto,HttpStatus.OK);

--- a/src/main/java/econo/buddybridge/utils/session/SessionUtils.java
+++ b/src/main/java/econo/buddybridge/utils/session/SessionUtils.java
@@ -7,4 +7,14 @@ public class SessionUtils {
     public static Long getMemberId(HttpServletRequest request) {
         return Long.parseLong(request.getSession().getAttribute("memberId").toString());
     }
+
+    public static Long validateMemberId(Object memberId){
+        if(memberId instanceof Integer){
+            return ((Integer) memberId).longValue();
+        } else if(memberId instanceof Long){
+            return (Long) memberId;
+        } else{
+            throw new IllegalArgumentException("적절하지 않은 memberId 입니다.");
+        }
+    }
 }


### PR DESCRIPTION
## PR 유형

- [X] 새로운 기능 추가
- [X] 버그 수정
- [X] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

WebSocket 사용시 로그인한 사용자의 Id를 가져와 사용
ChatMessageController에서 memberId를 검증하는 로직을 SessionUtils 파일에 추가
매칭 리스트 조회시 JPQL -> QueryDsl로 변경

## 참고 사항

추가적인 내용이나 주의사항 (없을 시 삭제)

## 관련 이슈

close #68 

## 체크리스트

- [X] 코드가 제대로 작동하는지 확인
- [X] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [X] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
