### PR TITLE
[FEAT] 채팅방 목록 조회 및 채팅방 조회 응답 객체 필드 추가, Matching에서 giver와 taker 올바른 매핑 설정

### DIFF
--- a/src/main/java/econo/buddybridge/chat/chatmessage/dto/ChatMessageCustomPage.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/dto/ChatMessageCustomPage.java
@@ -1,11 +1,16 @@
 package econo.buddybridge.chat.chatmessage.dto;
 
+import econo.buddybridge.matching.dto.ReceiverDto;
+import econo.buddybridge.post.entity.PostType;
 import lombok.Builder;
 
 import java.util.List;
 
 @Builder
 public record ChatMessageCustomPage(
+        PostType postType,
+        Long postId,
+        ReceiverDto receiver,
         List<ChatMessageResDto> chatMessages,
         Long cursor,
         Boolean nextPage

--- a/src/main/java/econo/buddybridge/matching/dto/MatchingResDto.java
+++ b/src/main/java/econo/buddybridge/matching/dto/MatchingResDto.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 public record MatchingResDto(
         Long matchingId,
         PostType postType,
+        Long postId,
         String lastMessage,
         LocalDateTime lastMessageTime,
         MessageType messageType,

--- a/src/main/java/econo/buddybridge/matching/service/MatchingRoomService.java
+++ b/src/main/java/econo/buddybridge/matching/service/MatchingRoomService.java
@@ -37,7 +37,7 @@ public class MatchingRoomService {
         Pageable pageable = PageRequest.of(0, size+1);
         Slice<Matching> matchingSlice;
 
-        if(cursor == null) {
+        if (cursor == null) {
             matchingSlice = matchingRepositoryCustom.findMatchingByTakerIdOrGiverId(memberId, pageable);
         } else { // 마지막 채팅 메시지 생성일자 기준 내림차순, cursor 값 이후에 생성된 내용 조회
             matchingSlice = matchingRepositoryCustom.findMatchingByTakerIdOrGiverIdAndIdLessThan(memberId, cursor, pageable);
@@ -49,7 +49,7 @@ public class MatchingRoomService {
                 .map(matching -> {
                     Member receiver = getReceiver(matching, memberId);
                     List<ChatMessage> massageList = chatMessageRepository.findLastMessageByMatchingId(matching.getId(), PageRequest.of(0, 1));
-                    if(massageList.isEmpty()) {
+                    if (massageList.isEmpty()) {
                         throw new IllegalArgumentException("마지막 메시지가 존재하지 않습니다.");
                     }
 
@@ -58,6 +58,7 @@ public class MatchingRoomService {
                     return MatchingResDto.builder()
                             .matchingId(matching.getId())
                             .postType(matching.getPost().getPostType())
+                            .postId(matching.getPost().getId())
                             .lastMessage(lastMessage.getContent())
                             .lastMessageTime(lastMessage.getCreatedAt())
                             .messageType(lastMessage.getMessageType())
@@ -84,7 +85,7 @@ public class MatchingRoomService {
         Pageable pageable = PageRequest.of(0, size+1);
         Slice<ChatMessage> chatMessagesSlice;
 
-        if(cursor == null) {
+        if (cursor == null) {
             chatMessagesSlice = chatMessageRepository.findByMatchingId(matchingId, pageable);
         } else {
             chatMessagesSlice = chatMessageRepository.findByMatchingIdAndIdGreaterThan(matchingId, cursor, pageable);
@@ -94,7 +95,7 @@ public class MatchingRoomService {
         Matching matching = matchingRepository.findById(matchingId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 매칭방입니다."));
 
-        if(!matching.getGiver().getId().equals(memberId) && !matching.getTaker().getId().equals(memberId)){
+        if (!matching.getGiver().getId().equals(memberId) && !matching.getTaker().getId().equals(memberId)){
             throw new IllegalArgumentException("사용자가 매칭방에 속해있지 않습니다.");
         }
 
@@ -117,7 +118,7 @@ public class MatchingRoomService {
 
     private Member getReceiver(Matching matching, Long memberId) {
         Long receiverId;
-        if(matching.getGiver().getId().equals(memberId)){
+        if (matching.getGiver().getId().equals(memberId)){
             receiverId = matching.getTaker().getId();
         } else {
             receiverId = matching.getGiver().getId();

--- a/src/main/java/econo/buddybridge/matching/service/MatchingRoomService.java
+++ b/src/main/java/econo/buddybridge/matching/service/MatchingRoomService.java
@@ -12,6 +12,7 @@ import econo.buddybridge.matching.repository.MatchingRepository;
 import econo.buddybridge.matching.repository.MatchingRepositoryCustom;
 import econo.buddybridge.member.entity.Member;
 import econo.buddybridge.member.repository.MemberRepository;
+import econo.buddybridge.post.entity.Post;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -99,6 +100,16 @@ public class MatchingRoomService {
             throw new IllegalArgumentException("사용자가 매칭방에 속해있지 않습니다.");
         }
 
+        Post post = matching.getPost();
+
+        Member receiver = getReceiver(matching, memberId);
+
+        ReceiverDto receiverDto = ReceiverDto.builder()
+                .receiverId(receiver.getId())
+                .receiverName(receiver.getNickname())
+                .receiverProfileImg(receiver.getProfileImageUrl())
+                .build();
+
         List<ChatMessage> chatMessageList = chatMessagesSlice.getContent();
 
         List<ChatMessageResDto> chatMessageResDtoList = chatMessageList.stream().limit(size)
@@ -113,7 +124,7 @@ public class MatchingRoomService {
         boolean nextPage = chatMessageList.size() > size;
 
         Long nextCursor = nextPage ? chatMessageResDtoList.isEmpty() ? -1L : chatMessageResDtoList.get(chatMessageResDtoList.size() - 1).messageId() : -1L;
-        return new ChatMessageCustomPage(chatMessageResDtoList, nextCursor, nextPage);
+        return new ChatMessageCustomPage(post.getPostType(), post.getId(), receiverDto, chatMessageResDtoList, nextCursor, nextPage);
     }
 
     private Member getReceiver(Matching matching, Long memberId) {

--- a/src/main/java/econo/buddybridge/matching/service/MatchingRoomService.java
+++ b/src/main/java/econo/buddybridge/matching/service/MatchingRoomService.java
@@ -90,7 +90,7 @@ public class MatchingRoomService {
             chatMessagesSlice = chatMessageRepository.findByMatchingIdAndIdGreaterThan(matchingId, cursor, pageable);
         }
 
-        // 사용자 확인 // ToDO: 예외처리 필요, 사용자가 매칭방에 속해있지 않을 경우 500 발생
+        // 사용자 확인 // TODO: 예외처리 필요, 사용자가 매칭방에 속해있지 않을 경우 500 발생
         Matching matching = matchingRepository.findById(matchingId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 매칭방입니다."));
 

--- a/src/main/java/econo/buddybridge/matching/service/MatchingService.java
+++ b/src/main/java/econo/buddybridge/matching/service/MatchingService.java
@@ -25,16 +25,25 @@ public class MatchingService {
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
 
-    @Transactional // 매칭 생성 -> 예외처리 필요
+    @Transactional // TODO: 매칭 생성 -> 예외처리 필요 + 댓글에서 사용자 정보 가져오기 고려
     public Long createMatchingById(MatchingReqDto matchingReqDto, Long memberId) {
         Post post = postRepository.findById(matchingReqDto.postId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
 
-        Member taker = memberRepository.findById(matchingReqDto.takerId())
+        Member loginMember = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
 
-        Member giver = memberRepository.findById(matchingReqDto.giverId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+        Member taker, giver;
+
+        if (post.getPostType() == PostType.GIVER) {
+            giver = loginMember;
+            taker = memberRepository.findById(matchingReqDto.takerId())
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+        } else {
+            giver = memberRepository.findById(matchingReqDto.giverId())
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+            taker = loginMember;
+        }
 
         validatePostAuthor(post, memberId);
 


### PR DESCRIPTION
## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [X] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

채팅방 목록 조회 및 채팅방 조회 응답 객체 필드 추가

Matching생성시 giver와 taker 올바른 매핑
기존 : taker 게시글 작성한 사람, giver 댓글 단 사람
변경 : taker 도움을 받는 사람, giver 도움을 주는 사람


## 관련 이슈관련 이슈

close #77 

## 체크리스트

- [X] 코드가 제대로 작동하는지 확인
- [X] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [X] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
