### PR TITLE
[FEAT] 게시글 댓글 알림 URL 변경

### DIFF
--- a/src/main/java/econo/buddybridge/comment/service/CommentService.java
+++ b/src/main/java/econo/buddybridge/comment/service/CommentService.java
@@ -10,6 +10,7 @@ import econo.buddybridge.member.repository.MemberRepository;
 import econo.buddybridge.notification.entity.NotificationType;
 import econo.buddybridge.notification.service.EmitterService;
 import econo.buddybridge.post.entity.Post;
+import econo.buddybridge.post.entity.PostType;
 import econo.buddybridge.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -56,12 +57,26 @@ public class CommentService {
 
         Comment comment = commentReqToComment(commentReqDto, post, member);
 
-        // 댓글 알림은 게시글 작성자에게 전송
         // 알림 내용은 댓글 작성자 이름과 댓글 내용
         String notificationContent = member.getName() + "님이 댓글을 남겼습니다. - " + comment.getContent();
-        emitterService.send(post.getAuthor(), notificationContent, "/api/posts/" + postId, NotificationType.COMMENT);
+        String notificationUrl = getCommentNotificationUrl(post.getPostType(), post.getId());
+
+        // 댓글 알림은 게시글 작성자에게 전송
+        emitterService.send(post.getAuthor(), notificationContent, notificationUrl, NotificationType.COMMENT);
 
         return commentRepository.save(comment).getId();
+    }
+
+    private String getCommentNotificationUrl(PostType postType, Long postId) {
+        switch (postType) {
+            case TAKER -> { // 도와줄래요? 게시글
+                return "/help-me" + postId;
+            }
+            case GIVER -> { // 도와줄게요! 게시글
+                return "/help-you/" + postId;
+            }
+        }
+        return "";
     }
 
     @Transactional  // 댓글 수정


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

기존의 `/posts/{post-id}` 형태의 알림 url을 프론트 라우팅에 맞게 변경

## 참고 사항

도와줄래요? : `/help-me/{id}`
도와줄게요! : `/help-you/{id}`

## 관련 이슈

close #79 

## 체크리스트

- [x] 코드가 제대로 작동하는지 확인
- [x] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [x] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
