### PR TITLE
[FIX]: 게시글 DisabilityType 직접 받아오기, 게시글 필터링 시 게시글의 DisabilityType 활용

### DIFF
--- a/src/main/java/econo/buddybridge/post/dto/PostReqDto.java
+++ b/src/main/java/econo/buddybridge/post/dto/PostReqDto.java
@@ -1,15 +1,11 @@
 package econo.buddybridge.post.dto;
 
+import econo.buddybridge.member.entity.DisabilityType;
 import econo.buddybridge.member.entity.Member;
-import econo.buddybridge.post.entity.AssistanceType;
-import econo.buddybridge.post.entity.District;
-import econo.buddybridge.post.entity.Post;
-import econo.buddybridge.post.entity.PostStatus;
-import econo.buddybridge.post.entity.PostType;
-import econo.buddybridge.post.entity.Schedule;
-import econo.buddybridge.post.entity.ScheduleType;
-import java.time.LocalDateTime;
+import econo.buddybridge.post.entity.*;
 import lombok.Builder;
+
+import java.time.LocalDateTime;
 
 @Builder
 public record PostReqDto(
@@ -22,7 +18,8 @@ public record PostReqDto(
         String scheduleDetails,
         District district,
         String content,
-        PostType postType
+        PostType postType,
+        DisabilityType disabilityType
 ) {
 
     public Post toEntity(Member author) {
@@ -40,6 +37,7 @@ public record PostReqDto(
                 .content(content)
                 .postType(postType)
                 .postStatus(PostStatus.RECRUITING)
+                .disabilityType(disabilityType)
                 .build();
     }
 }

--- a/src/main/java/econo/buddybridge/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/econo/buddybridge/post/repository/PostRepositoryImpl.java
@@ -83,8 +83,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 
     // 없음, 시각장애, 청각장애, 지적장애, 지체장애, 자폐성장애, 뇌병변장애, 정신장애
     private BooleanExpression buildPostDisabilityTypeExpression(DisabilityType disabilityType) {
-//        return disabilityType == null ? null : post.disabilityType.eq(disabilityType);
-        return disabilityType == null ? null : post.author.disabilityType.eq(disabilityType);
+        return disabilityType == null ? null : post.disabilityType.eq(disabilityType);
     }
 
     // 광주광역시, 남구, 북구, 서구, 동구, 광산구


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

기존
게시글의 DisabilityType이 null로 생성

수정
게시글의 DisabilityType을 FE에서 직접 받아와 생성
게시글 필터링 시 게시글의 DisabilityType에 따라 게시글 조회

## 관련 이슈

close #135 

## 체크리스트

- [X] 코드가 제대로 작동하는지 확인
- [X] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [X] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
