### PR TITLE
[FIX] isLiked 필드가 null로 반환 되는 오류

### DIFF
--- a/src/main/java/econo/buddybridge/post/dto/PostResDto.java
+++ b/src/main/java/econo/buddybridge/post/dto/PostResDto.java
@@ -44,7 +44,7 @@ public record PostResDto(
                 post.getModifiedAt(),
                 post.getPostStatus(),
                 post.getDisabilityType(),
-                post.getIsLiked()
+                false
         );
     }
 

--- a/src/main/java/econo/buddybridge/post/entity/Post.java
+++ b/src/main/java/econo/buddybridge/post/entity/Post.java
@@ -62,8 +62,6 @@ public class Post extends BaseEntity {
     @OneToMany(mappedBy = "post", orphanRemoval = true, cascade = CascadeType.ALL)
     private final List<Comment> comments = new ArrayList<>();
 
-    private Boolean isLiked = false;
-
     public void changeStatus(PostStatus status){ // 상태 변경
         this.postStatus = status;
     }

--- a/src/main/java/econo/buddybridge/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/econo/buddybridge/post/repository/PostRepositoryImpl.java
@@ -66,7 +66,6 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                         buildPostDisabilityTypeExpression(disabilityType), buildPostAssistanceTypeExpression(assistanceType))
                 .fetchOne();
 
-        // content, totalElements, last
         return new PostCustomPage(content, totalElements, content.size() < size);
     }
 


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

Post Entity의 isLiked 필드 제거
PostResDto생성 시 PostLike를 조회하여 isLiked 반환 값 결정

## 관련 이슈

close #159 

## 체크리스트

- [X] 코드가 제대로 작동하는지 확인
- [X] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [X] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
