### PR TITLE
[FEAT] 게시글 당 댓글을 한 번만 작성 가능

### DIFF
--- a/src/main/java/econo/buddybridge/comment/exception/CommentAlreadyWrittenException.java
+++ b/src/main/java/econo/buddybridge/comment/exception/CommentAlreadyWrittenException.java
@@ -1,0 +1,12 @@
+package econo.buddybridge.comment.exception;
+
+import econo.buddybridge.common.exception.BusinessException;
+
+public class CommentAlreadyWrittenException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new CommentAlreadyWrittenException();
+
+    private CommentAlreadyWrittenException() {
+        super(CommentErrorCode.COMMENT_ALREADY_WRITTEN);
+    }
+}

--- a/src/main/java/econo/buddybridge/comment/exception/CommentErrorCode.java
+++ b/src/main/java/econo/buddybridge/comment/exception/CommentErrorCode.java
@@ -8,6 +8,7 @@ public enum CommentErrorCode implements ErrorCode {
     COMMENT_UPDATE_NOT_ALLOWED("C002", HttpStatus.FORBIDDEN, "본인의 댓글만 수정할 수 있습니다."),
     COMMENT_DELETE_NOT_ALLOWED("C003", HttpStatus.FORBIDDEN, "본인의 댓글만 삭제할 수 있습니다."),
     COMMENT_INVALID_DIRECTION("C004", HttpStatus.BAD_REQUEST, "올바르지 않은 정렬 방식입니다."),
+    COMMENT_ALREADY_WRITTEN("C005", HttpStatus.BAD_REQUEST, "이미 댓글을 작성했습니다. 댓글은 하나만 작성할 수 있습니다.")
     ;
 
     private final String code;

--- a/src/main/java/econo/buddybridge/comment/repository/CommentRepository.java
+++ b/src/main/java/econo/buddybridge/comment/repository/CommentRepository.java
@@ -1,8 +1,11 @@
 package econo.buddybridge.comment.repository;
 
 import econo.buddybridge.comment.entity.Comment;
+import econo.buddybridge.member.entity.Member;
+import econo.buddybridge.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
 
+    boolean existsByPostAndAuthor(Post post, Member author);
 }

--- a/src/main/java/econo/buddybridge/comment/service/CommentService.java
+++ b/src/main/java/econo/buddybridge/comment/service/CommentService.java
@@ -7,6 +7,7 @@ import econo.buddybridge.comment.dto.CommentCustomPage;
 import econo.buddybridge.comment.dto.CommentReqDto;
 import econo.buddybridge.comment.dto.MyPageCommentCustomPage;
 import econo.buddybridge.comment.entity.Comment;
+import econo.buddybridge.comment.exception.CommentAlreadyWrittenException;
 import econo.buddybridge.comment.exception.CommentDeleteNotAllowedException;
 import econo.buddybridge.comment.exception.CommentInvalidDirectionException;
 import econo.buddybridge.comment.exception.CommentNotFoundException;
@@ -58,10 +59,13 @@ public class CommentService {
 
     @Transactional  // 댓글 생성
     public Long createComment(CommentReqDto commentReqDto, Long postId, Long memberId) {
-
         Member member = memberService.findMemberByIdOrThrow(memberId);
-
         Post post = postService.findPostByIdOrThrow(postId);
+
+        // 기존에 댓글을 작성한 적이 있는지 확인하고 있다면 댓글 작성 불가
+        if (commentRepository.existsByPostAndAuthor(post, member)) {
+            throw CommentAlreadyWrittenException.EXCEPTION;
+        }
 
         Comment comment = commentReqToComment(commentReqDto, post, member);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,10 @@ spring:
     username: ${MARIA_USER}
     password: ${MARIA_PASSWORD}
     driver-class-name: org.mariadb.jdbc.Driver
+    hikari:
+      minimum-idle: 2
+      maximum-pool-size: 8
+      connection-timeout: 30000 # connection 획득 시도 후 실패 시 대기 시간
 
   jpa:
     hibernate:


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

- 사용자마다 각 게시글에 댓글을 한 번만 달 수 있음
- 데이터베이스 최소/최대 pool 개수와 `connection-timeout` 설정

## 참고 사항

[[Spring Boot] Hikari CP 커스텀으로 성능 최적화하기](https://velog.io/@dongvelop/Spring-Boot-Hikari-CP-%EC%BB%A4%EC%8A%A4%ED%85%80%EC%9C%BC%EB%A1%9C-%EC%84%B1%EB%8A%A5-%EC%B5%9C%EC%A0%81%ED%99%94%ED%95%98%EA%B8%B0#%EB%8D%B0%EB%93%9C%EB%9D%BD-%ED%94%BC%ED%95%98%EA%B8%B0)

DB 연결 관련 설정은 부하 테스트 등 여러 시도로 최적화된 값을 고려해야될 것 같습니다.
현재 상황에서 커넥션 10개를 물고 `idle` 상태로 존재하길래 최소 2, 최대 8개로 두고 타임아웃 설정도 추가했습니다.

## 관련 이슈

close #183 

## 체크리스트

- [x] 코드가 제대로 작동하는지 확인
- [x] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [x] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
