### PR TITLE
[FEAT] 로그아웃 및 채팅 인가 방식 변경

### DIFF
--- a/src/main/java/econo/buddybridge/auth/controller/AuthController.java
+++ b/src/main/java/econo/buddybridge/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package econo.buddybridge.auth.controller;
 import econo.buddybridge.auth.dto.LoginReqDto;
 import econo.buddybridge.auth.jwt.AuthToken;
 import econo.buddybridge.auth.resolver.MemberToken;
+import econo.buddybridge.auth.resolver.MemberTokenId;
 import econo.buddybridge.auth.service.AuthService;
 import econo.buddybridge.common.annotation.AllowAnonymous;
 import econo.buddybridge.member.dto.MemberSignUpReqDto;
@@ -26,6 +27,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auth")
 @Tag(name = "인증 API", description = "인증 관련 API")
 public class AuthController {
+
+    private static final String LOGOUT_SUCCESS_MESSAGE = "로그아웃 성공";
 
     private final AuthService authService;
 
@@ -57,5 +60,14 @@ public class AuthController {
     ) {
         AuthToken authToken = authService.reissue(token);
         return ApiResponseGenerator.success(authToken, HttpStatus.OK);
+    }
+
+    @Operation(summary = "로그아웃", description = "로그아웃합니다.")
+    @PostMapping("/logout")
+    public ApiResponse<CustomBody<String>> logout(
+            @Parameter(hidden = true) @MemberTokenId Long memberId
+    ) {
+        authService.logout(memberId);
+        return ApiResponseGenerator.success(LOGOUT_SUCCESS_MESSAGE, HttpStatus.OK);
     }
 }

--- a/src/main/java/econo/buddybridge/auth/controller/AuthController.java
+++ b/src/main/java/econo/buddybridge/auth/controller/AuthController.java
@@ -55,8 +55,7 @@ public class AuthController {
     @Operation(summary = "Access Token, Refresh Token 재발급", description = "Refresh Token을 이용해 Access Token과 Refresh Token을 재발급합니다.")
     @PostMapping("/reissue")
     public ApiResponse<CustomBody<AuthToken>> reissue(
-            @Parameter(hidden = true)
-            @MemberToken String token
+            @Parameter(hidden = true) @MemberToken String token
     ) {
         AuthToken authToken = authService.reissue(token);
         return ApiResponseGenerator.success(authToken, HttpStatus.OK);

--- a/src/main/java/econo/buddybridge/auth/controller/AuthController.java
+++ b/src/main/java/econo/buddybridge/auth/controller/AuthController.java
@@ -51,7 +51,10 @@ public class AuthController {
 
     @Operation(summary = "Access Token, Refresh Token 재발급", description = "Refresh Token을 이용해 Access Token과 Refresh Token을 재발급합니다.")
     @PostMapping("/reissue")
-    public ApiResponse<CustomBody<AuthToken>> reissue(@Parameter(hidden = true) @MemberToken String token) {
+    public ApiResponse<CustomBody<AuthToken>> reissue(
+            @Parameter(hidden = true)
+            @MemberToken String token
+    ) {
         AuthToken authToken = authService.reissue(token);
         return ApiResponseGenerator.success(authToken, HttpStatus.OK);
     }

--- a/src/main/java/econo/buddybridge/auth/jwt/exception/JwtErrorCode.java
+++ b/src/main/java/econo/buddybridge/auth/jwt/exception/JwtErrorCode.java
@@ -8,7 +8,7 @@ public enum JwtErrorCode implements ErrorCode {
     INVALID_REFRESH_TOKEN("JW002", HttpStatus.UNAUTHORIZED, "올바른 REFRESH 토큰이 아닙니다."),
     EXPIRED_TOKEN("JW003", HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
     MISSING_TOKEN("JW004", HttpStatus.UNAUTHORIZED, "요청에 토큰이 포함되어있지 않습니다."),
-    LOGGED_OUT_TOKEN("JW005", HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다. 다시 로그인해주세요."),
+    LOGGED_OUT_TOKEN("JW005", HttpStatus.UNAUTHORIZED, "이미 로그아웃된 상태입니다."),
     ;
 
     private final String code;

--- a/src/main/java/econo/buddybridge/auth/jwt/exception/JwtErrorCode.java
+++ b/src/main/java/econo/buddybridge/auth/jwt/exception/JwtErrorCode.java
@@ -8,6 +8,7 @@ public enum JwtErrorCode implements ErrorCode {
     INVALID_REFRESH_TOKEN("JW002", HttpStatus.UNAUTHORIZED, "올바른 REFRESH 토큰이 아닙니다."),
     EXPIRED_TOKEN("JW003", HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
     MISSING_TOKEN("JW004", HttpStatus.UNAUTHORIZED, "요청에 토큰이 포함되어있지 않습니다."),
+    LOGGED_OUT_TOKEN("JW005", HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다. 다시 로그인해주세요."),
     ;
 
     private final String code;

--- a/src/main/java/econo/buddybridge/auth/jwt/exception/JwtErrorCode.java
+++ b/src/main/java/econo/buddybridge/auth/jwt/exception/JwtErrorCode.java
@@ -6,8 +6,8 @@ import org.springframework.http.HttpStatus;
 public enum JwtErrorCode implements ErrorCode {
     INVALID_ACCESS_TOKEN("JW001", HttpStatus.UNAUTHORIZED, "올바른 ACCESS 토큰이 아닙니다."),
     INVALID_REFRESH_TOKEN("JW002", HttpStatus.UNAUTHORIZED, "올바른 REFRESH 토큰이 아닙니다."),
-    EXPIRED_TOKEN("JW002", HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
-    MISSING_TOKEN("JW003", HttpStatus.UNAUTHORIZED, "요청에 토큰이 포함되어있지 않습니다."),
+    EXPIRED_TOKEN("JW003", HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+    MISSING_TOKEN("JW004", HttpStatus.UNAUTHORIZED, "요청에 토큰이 포함되어있지 않습니다."),
     ;
 
     private final String code;

--- a/src/main/java/econo/buddybridge/auth/jwt/exception/LoggedOutTokenException.java
+++ b/src/main/java/econo/buddybridge/auth/jwt/exception/LoggedOutTokenException.java
@@ -1,0 +1,12 @@
+package econo.buddybridge.auth.jwt.exception;
+
+import econo.buddybridge.common.exception.BusinessException;
+
+public class LoggedOutTokenException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new LoggedOutTokenException();
+
+    private LoggedOutTokenException() {
+        super(JwtErrorCode.LOGGED_OUT_TOKEN);
+    }
+}

--- a/src/main/java/econo/buddybridge/auth/jwt/service/AuthTokenService.java
+++ b/src/main/java/econo/buddybridge/auth/jwt/service/AuthTokenService.java
@@ -36,4 +36,9 @@ public class AuthTokenService {
 
         return generateAuthToken(memberId);
     }
+
+    @Transactional
+    public void logout(Long memberId) {
+        jwtTokenProvider.deleteByMemberId(memberId);
+    }
 }

--- a/src/main/java/econo/buddybridge/auth/jwt/service/JwtTokenProvider.java
+++ b/src/main/java/econo/buddybridge/auth/jwt/service/JwtTokenProvider.java
@@ -9,6 +9,7 @@ import econo.buddybridge.auth.jwt.exception.LoggedOutTokenException;
 import econo.buddybridge.auth.jwt.exception.MissingTokenException;
 import econo.buddybridge.auth.jwt.repository.TokenRepository;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
@@ -94,15 +95,7 @@ public class JwtTokenProvider {
     }
 
     public boolean validateToken(String token, TokenType tokenType) {
-        // Todo : 토큰 만료 시간이 지났는데 parseClaims가 호출되어 토큰 만료가 아닌 올바른 토큰이 아니라는 예외 발생
-        Claims claims = parseClaims(token, tokenType);
-
-        // Todo : parseClaims에서 JWT 라이브러리가 발생시키는 예외를 catch에서 잡기
-        Date expiration = claims.getExpiration();
-        if (expiration.before(new Date())) {
-            throw ExpiredTokenException.EXCEPTION;
-        }
-
+        parseClaims(token, tokenType);
         return true;
     }
 
@@ -118,7 +111,9 @@ public class JwtTokenProvider {
                     .build()
                     .parseSignedClaims(token)
                     .getPayload();
-        } catch (Exception e) { // Todo : 구체적인 예외 잡고, Exception으로 넘어가기
+        } catch (ExpiredJwtException e) {
+            throw ExpiredTokenException.EXCEPTION;
+        } catch (Exception e) {
             if (tokenType.equals(TokenType.ACCESS)) {
                 throw InvalidAccessTokenException.EXCEPTION;
             }

--- a/src/main/java/econo/buddybridge/auth/jwt/service/JwtTokenProvider.java
+++ b/src/main/java/econo/buddybridge/auth/jwt/service/JwtTokenProvider.java
@@ -5,17 +5,19 @@ import econo.buddybridge.auth.jwt.TokenType;
 import econo.buddybridge.auth.jwt.exception.ExpiredTokenException;
 import econo.buddybridge.auth.jwt.exception.InvalidAccessTokenException;
 import econo.buddybridge.auth.jwt.exception.InvalidRefreshTokenException;
+import econo.buddybridge.auth.jwt.exception.LoggedOutTokenException;
 import econo.buddybridge.auth.jwt.exception.MissingTokenException;
 import econo.buddybridge.auth.jwt.repository.TokenRepository;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
 import java.time.Duration;
 import java.util.Date;
 import java.util.Optional;
-import javax.crypto.SecretKey;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
 
 @Component
 public class JwtTokenProvider {
@@ -92,8 +94,10 @@ public class JwtTokenProvider {
     }
 
     public boolean validateToken(String token, TokenType tokenType) {
+        // Todo : 토큰 만료 시간이 지났는데 parseClaims가 호출되어 토큰 만료가 아닌 올바른 토큰이 아니라는 예외 발생
         Claims claims = parseClaims(token, tokenType);
 
+        // Todo : parseClaims에서 JWT 라이브러리가 발생시키는 예외를 catch에서 잡기
         Date expiration = claims.getExpiration();
         if (expiration.before(new Date())) {
             throw ExpiredTokenException.EXCEPTION;
@@ -114,11 +118,21 @@ public class JwtTokenProvider {
                     .build()
                     .parseSignedClaims(token)
                     .getPayload();
-        } catch (Exception e) {
+        } catch (Exception e) { // Todo : 구체적인 예외 잡고, Exception으로 넘어가기
             if (tokenType.equals(TokenType.ACCESS)) {
                 throw InvalidAccessTokenException.EXCEPTION;
             }
             throw InvalidRefreshTokenException.EXCEPTION;
+        }
+    }
+
+    public void deleteByMemberId(Long memberId) {
+        tokenRepository.deleteById(memberId);
+    }
+
+    public void existsByMemberId(Long memberId) {
+        if (!tokenRepository.existsById(memberId)) {
+            throw LoggedOutTokenException.EXCEPTION;
         }
     }
 }

--- a/src/main/java/econo/buddybridge/auth/service/AuthService.java
+++ b/src/main/java/econo/buddybridge/auth/service/AuthService.java
@@ -33,4 +33,9 @@ public class AuthService {
     public AuthToken reissue(String refreshToken) {
         return authTokenService.reissue(refreshToken);
     }
+
+    @Transactional
+    public void logout(Long memberId) {
+        authTokenService.logout(memberId);
+    }
 }

--- a/src/main/java/econo/buddybridge/chat/chatmessage/controller/ChatMessageController.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/controller/ChatMessageController.java
@@ -4,10 +4,13 @@ import econo.buddybridge.chat.chatmessage.dto.ChatMessageReqDto;
 import econo.buddybridge.chat.chatmessage.dto.ChatMessageResDto;
 import econo.buddybridge.chat.chatmessage.service.ChatMessageService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.messaging.handler.annotation.*;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Map;
+import java.security.Principal;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,10 +23,9 @@ public class ChatMessageController {
     public ChatMessageResDto sendMessage(
             @DestinationVariable("matching-id") Long matchingId,
             @Payload ChatMessageReqDto chatMessageReqDto,
-            @Header("simpSessionAttributes") Map<String, Object> attributes
+            Principal principal
     ) {
-        Object memberIdObject = attributes.get("memberId");
-        Long senderId = Long.parseLong(memberIdObject.toString());
+        Long senderId = Long.parseLong(principal.getName());
         return chatMessageService.save(senderId, chatMessageReqDto, matchingId);
     }
 }

--- a/src/main/java/econo/buddybridge/config/JwtInterceptor.java
+++ b/src/main/java/econo/buddybridge/config/JwtInterceptor.java
@@ -44,6 +44,10 @@ public class JwtInterceptor implements HandlerInterceptor {
             return jwtTokenProvider.validateToken(token, TokenType.REFRESH);
         }
 
+        // Access Token에서 memberId 추출 후 Refresh Token이 tokenRepository에 존재하는지 확인
+        Long memberId = jwtTokenProvider.getMemberIdFromAccessToken(token);
+        jwtTokenProvider.existsByMemberId(memberId);
+
         return jwtTokenProvider.validateToken(token, TokenType.ACCESS);
     }
 }

--- a/src/main/java/econo/buddybridge/config/StompChannelInterceptor.java
+++ b/src/main/java/econo/buddybridge/config/StompChannelInterceptor.java
@@ -26,37 +26,52 @@ public class StompChannelInterceptor implements ChannelInterceptor {
 
     private final static String PREFIX = "Bearer ";
     private final static String AUTHORIZATION = "Authorization";
-    private final static String MEMBER_ID = "memberId";
 
     @Override // 커스텀 헤더의 JWT를 가져옴
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
-        processAuthentication(accessor);
+
+        if (accessor != null) {
+            processAuthentication(accessor);
+        }
+
         return message;
     }
 
     private void processAuthentication(StompHeaderAccessor accessor) {
-        if (accessor != null && accessor.getCommand() == StompCommand.CONNECT) { // 연결 시 헤더 확인
-            String token = Objects.requireNonNull(accessor.getFirstNativeHeader(AUTHORIZATION));
 
-            if (!token.startsWith(PREFIX)) {
-                throw InvalidAccessTokenException.EXCEPTION;
-            }
+        if (accessor.getCommand() == StompCommand.CONNECT) {
+            log.info("STOMP COMMAND : {}", accessor.getCommand());
+            Long memberId = validateAndGetMemberId(accessor);
+            setPrincipal(accessor, memberId);
+        }
 
-            token = token.replace(PREFIX, "");
-            validateAndSetHeader(token, accessor);
+        if (accessor.getCommand() == StompCommand.SEND) {
+            validateAndGetMemberId(accessor);
         }
     }
+    
+    private Long validateAndGetMemberId(StompHeaderAccessor accessor) {
+        String token = Objects.requireNonNull(accessor.getFirstNativeHeader(AUTHORIZATION));
 
-    private void validateAndSetHeader(String token, StompHeaderAccessor accessor) {
+        if (!token.startsWith(PREFIX)) {
+            throw InvalidAccessTokenException.EXCEPTION;
+        }
+
+        token = token.replace(PREFIX, "");
         jwtTokenProvider.validateToken(token, TokenType.ACCESS);
-        Long memberId = jwtTokenProvider.getMemberIdFromAccessToken(token);
-        accessor.addNativeHeader(MEMBER_ID, memberId.toString());
-        accessor.setUser(new Principal() {
-            @Override
-            public String getName() {
-                return memberId.toString();
-            }
-        });
+        return jwtTokenProvider.getMemberIdFromAccessToken(token);
+    }
+
+    private void setPrincipal(StompHeaderAccessor accessor, Long memberId) {
+
+        if (accessor.getUser() == null) {
+            accessor.setUser(new Principal() {
+                @Override
+                public String getName() {
+                    return memberId.toString();
+                }
+            });
+        }
     }
 }

--- a/src/main/java/econo/buddybridge/config/StompChannelInterceptor.java
+++ b/src/main/java/econo/buddybridge/config/StompChannelInterceptor.java
@@ -37,35 +37,26 @@ public class StompChannelInterceptor implements ChannelInterceptor {
 
     private void processAuthentication(StompHeaderAccessor accessor) {
         if (accessor != null && accessor.getCommand() == StompCommand.CONNECT) { // 연결 시 헤더 확인
-            try {
-                String token = Objects.requireNonNull(accessor.getFirstNativeHeader(AUTHORIZATION));
+            String token = Objects.requireNonNull(accessor.getFirstNativeHeader(AUTHORIZATION));
 
-                if (!token.startsWith(PREFIX)) {
-                    throw InvalidAccessTokenException.EXCEPTION;
-                }
-
-                token = token.replace(PREFIX, "");
-                validateAndSetHeader(token, accessor);
-            } catch (Exception e) {
-                log.error("인가 실패 : {}", e.getMessage());
+            if (!token.startsWith(PREFIX)) {
                 throw InvalidAccessTokenException.EXCEPTION;
             }
+
+            token = token.replace(PREFIX, "");
+            validateAndSetHeader(token, accessor);
         }
     }
 
     private void validateAndSetHeader(String token, StompHeaderAccessor accessor) {
-        try {
-            jwtTokenProvider.validateToken(token, TokenType.ACCESS);
-            Long memberId = jwtTokenProvider.getMemberIdFromAccessToken(token);
-            accessor.addNativeHeader(MEMBER_ID, memberId.toString());
-            accessor.setUser(new Principal() {
-                @Override
-                public String getName() {
-                    return memberId.toString();
-                }
-            });
-        } catch (Exception e) {
-            throw InvalidAccessTokenException.EXCEPTION;
-        }
+        jwtTokenProvider.validateToken(token, TokenType.ACCESS);
+        Long memberId = jwtTokenProvider.getMemberIdFromAccessToken(token);
+        accessor.addNativeHeader(MEMBER_ID, memberId.toString());
+        accessor.setUser(new Principal() {
+            @Override
+            public String getName() {
+                return memberId.toString();
+            }
+        });
     }
 }

--- a/src/main/java/econo/buddybridge/config/StompChannelInterceptor.java
+++ b/src/main/java/econo/buddybridge/config/StompChannelInterceptor.java
@@ -1,0 +1,71 @@
+package econo.buddybridge.config;
+
+
+import econo.buddybridge.auth.jwt.TokenType;
+import econo.buddybridge.auth.jwt.exception.InvalidAccessTokenException;
+import econo.buddybridge.auth.jwt.service.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class StompChannelInterceptor implements ChannelInterceptor {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    private final static String PREFIX = "Bearer ";
+    private final static String AUTHORIZATION = "Authorization";
+    private final static String MEMBER_ID = "memberId";
+
+    @Override // 커스텀 헤더의 JWT를 가져옴
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        processAuthentication(accessor);
+        return message;
+    }
+
+    private void processAuthentication(StompHeaderAccessor accessor) {
+        if (accessor != null && accessor.getCommand() == StompCommand.CONNECT) { // 연결 시 헤더 확인
+            try {
+                String token = Objects.requireNonNull(accessor.getFirstNativeHeader(AUTHORIZATION));
+
+                if (!token.startsWith(PREFIX)) {
+                    throw InvalidAccessTokenException.EXCEPTION;
+                }
+
+                token = token.replace(PREFIX, "");
+                validateAndSetHeader(token, accessor);
+            } catch (Exception e) {
+                log.error("인가 실패 : {}", e.getMessage());
+                throw InvalidAccessTokenException.EXCEPTION;
+            }
+        }
+    }
+
+    private void validateAndSetHeader(String token, StompHeaderAccessor accessor) {
+        try {
+            jwtTokenProvider.validateToken(token, TokenType.ACCESS);
+            Long memberId = jwtTokenProvider.getMemberIdFromAccessToken(token);
+            accessor.addNativeHeader(MEMBER_ID, memberId.toString());
+            accessor.setUser(new Principal() {
+                @Override
+                public String getName() {
+                    return memberId.toString();
+                }
+            });
+        } catch (Exception e) {
+            throw InvalidAccessTokenException.EXCEPTION;
+        }
+    }
+}

--- a/src/main/java/econo/buddybridge/config/StompConfig.java
+++ b/src/main/java/econo/buddybridge/config/StompConfig.java
@@ -1,22 +1,24 @@
-package econo.buddybridge.websocket;
+package econo.buddybridge.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
-import org.springframework.session.MapSession;
-import org.springframework.session.web.socket.config.annotation.AbstractSessionWebSocketMessageBrokerConfigurer;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
-import org.springframework.web.socket.server.support.HttpSessionHandshakeInterceptor;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 @Configuration
 @EnableWebSocketMessageBroker
-public class StompConfig extends AbstractSessionWebSocketMessageBrokerConfigurer<MapSession> {
+@RequiredArgsConstructor
+public class StompConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final StompChannelInterceptor stompChannelInterceptor;
 
     @Override
-    protected void configureStompEndpoints(StompEndpointRegistry registry) {
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/socket/connect") // ws://{BASE_URL}/socket/connect 로 연결 설정
-                .setAllowedOriginPatterns("*") // CORS 허용
-                .addInterceptors(new HttpSessionHandshakeInterceptor());
+                .setAllowedOriginPatterns("*"); // CORS 허용
     }
 
     @Override
@@ -29,5 +31,11 @@ public class StompConfig extends AbstractSessionWebSocketMessageBrokerConfigurer
         // 발행 경로에 사용(클라이언트 -> 서버)
 
         registry.setPreservePublishOrder(true); // 발행 순서 보장
+    }
+
+    // Stomp 연결 시도 시 호출
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompChannelInterceptor);
     }
 }

--- a/src/main/java/econo/buddybridge/config/WebConfig.java
+++ b/src/main/java/econo/buddybridge/config/WebConfig.java
@@ -2,13 +2,14 @@ package econo.buddybridge.config;
 
 import econo.buddybridge.auth.resolver.MemberTokenIdResolver;
 import econo.buddybridge.auth.resolver.MemberTokenResolver;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
@@ -42,7 +43,9 @@ public class WebConfig implements WebMvcConfigurer {
                         "/api/oauth/logout",
                         "/swagger-ui/**",
                         "/swagger-resources/**",
-                        "/v3/api-docs/**"
+                        "/v3/api-docs/**",
+                        "/api/auth/signup",
+                        "/api/auth/login"
                 );
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,6 +61,13 @@ logging:
   file: # 로그 파일 설정
     name: /app/application.log
 
+  logback:
+    rollingpolicy:
+      max-history: 30
+      max-file-size: 50MB
+      file-name-pattern: /app/application-%d{yyyy-MM-dd}-%i.log
+      total-size-cap: 2GB
+
 # Register P6LogFactory to log JDBC events
 decorator:
   datasource:


### PR DESCRIPTION
## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [X] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

로그아웃 요청이 들어오면 `tokenRepository`의 `refreshToken` 제거

인가가 필요한 요청에 대해서 `JWTInterceptor`에서 토큰 검증을 거쳐 `refreshToken`
- 있는 경우 로그인한 사용자
- 없는 경우 로그아웃한 사용자

채팅 메시지 인가 방식 변경
`AbstractSessionWebSocketMessageBrokerConfigurer` -> `WebSocketMessageBrokerConfigurer`
더 이상 Http Session을 사용 안 함

## 참고 사항
```
logging:
  file: # 로그 파일 설정
    name: /app/application.log

  logback:
    rollingpolicy:
      max-history: 30
      max-file-size: 50MB
      file-name-pattern: /app/application-%d{yyyy-MM-dd}-%i.log
      total-size-cap: 2GB
```

logging rotation을 적용 시켜 file이 여러 개 생성되므로 개발 서버의
`docker-compose.yml`에서 /app/application.log로 단일 파일에서 /app 디렉터리로 변경 필요
```
  backend:
    ...
    volumes: 
    # 기존: - ~/buddies/log/server.log:/app/application.log
      - ~/buddies/log/server.log:/app 
```



## 관련 이슈

close #208 

## 체크리스트

- [X] 코드가 제대로 작동하는지 확인
- [X] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [X] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
