### PR TITLE
[FIX] 카카오 소셜로그인 Redirect시 토큰을 쿼리파라미터로 전달하도록 수정

### DIFF
--- a/src/main/java/econo/buddybridge/auth/controller/OAuthController.java
+++ b/src/main/java/econo/buddybridge/auth/controller/OAuthController.java
@@ -15,11 +15,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,8 +28,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.net.URI;
 
 @Slf4j
 @RestController
@@ -57,16 +56,18 @@ public class OAuthController {
 
     @Operation(summary = "카카오 소셜 로그인 (코드로 로그인)", description = "Redirect URL이 백엔드 주소로 설정될 때 사용합니다.")
     @GetMapping("/login")
-    public ApiResponse<CustomBody<AuthToken>> login(@RequestParam("code") String code) {
+    public void login(@RequestParam("code") String code, HttpServletResponse response) throws IOException {
         KakaoLoginParams params = new KakaoLoginParams(code);
 
         AuthToken authToken = oAuthLoginService.loginWithToken(params);
 
-        // 프론트엔드 주소로 redirect
-        HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.setLocation(URI.create(frontUrl));
+        String redirectUrl = String.format("%s/?accessToken=%s&refreshToken=%s",
+                frontUrl,
+                authToken.accessToken(),
+                authToken.refreshToken()
+        );
 
-        return ApiResponseGenerator.success(authToken, httpHeaders, HttpStatus.PERMANENT_REDIRECT);
+        response.sendRedirect(redirectUrl);
     }
 
     @Operation(summary = "카카오 소셜 로그인 (토큰으로 로그인)", description = "Redirect URL이 프론트엔드 주소로 설정될 때 사용합니다.")


### PR DESCRIPTION
resolve #218

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약
- 프론트엔드 URL의 쿼리 파라미터로 토큰을 포함하여 리다이렉트

## 관련 이슈

close #218 

## 체크리스트

- [x] 코드가 제대로 작동하는지 확인
- [x] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [x] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
