### PR TITLE
[FEAT] 로그아웃 기능 구현

### DIFF
--- a/src/main/java/econo/buddybridge/auth/controller/AuthController.java
+++ b/src/main/java/econo/buddybridge/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package econo.buddybridge.auth.controller;
 import econo.buddybridge.auth.dto.LoginReqDto;
 import econo.buddybridge.auth.jwt.AuthToken;
 import econo.buddybridge.auth.resolver.MemberToken;
+import econo.buddybridge.auth.resolver.MemberTokenId;
 import econo.buddybridge.auth.service.AuthService;
 import econo.buddybridge.common.annotation.AllowAnonymous;
 import econo.buddybridge.member.dto.MemberSignUpReqDto;
@@ -26,6 +27,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auth")
 @Tag(name = "인증 API", description = "인증 관련 API")
 public class AuthController {
+
+    private static final String LOGOUT_SUCCESS_MESSAGE = "로그아웃 성공";
 
     private final AuthService authService;
 
@@ -57,5 +60,14 @@ public class AuthController {
     ) {
         AuthToken authToken = authService.reissue(token);
         return ApiResponseGenerator.success(authToken, HttpStatus.OK);
+    }
+
+    @Operation(summary = "로그아웃", description = "로그아웃합니다.")
+    @PostMapping("/logout")
+    public ApiResponse<CustomBody<String>> logout(
+            @Parameter(hidden = true) @MemberTokenId Long memberId
+    ) {
+        authService.logout(memberId);
+        return ApiResponseGenerator.success(LOGOUT_SUCCESS_MESSAGE, HttpStatus.OK);
     }
 }

--- a/src/main/java/econo/buddybridge/auth/controller/AuthController.java
+++ b/src/main/java/econo/buddybridge/auth/controller/AuthController.java
@@ -55,8 +55,7 @@ public class AuthController {
     @Operation(summary = "Access Token, Refresh Token 재발급", description = "Refresh Token을 이용해 Access Token과 Refresh Token을 재발급합니다.")
     @PostMapping("/reissue")
     public ApiResponse<CustomBody<AuthToken>> reissue(
-            @Parameter(hidden = true)
-            @MemberToken String token
+            @Parameter(hidden = true) @MemberToken String token
     ) {
         AuthToken authToken = authService.reissue(token);
         return ApiResponseGenerator.success(authToken, HttpStatus.OK);

--- a/src/main/java/econo/buddybridge/auth/controller/AuthController.java
+++ b/src/main/java/econo/buddybridge/auth/controller/AuthController.java
@@ -51,7 +51,10 @@ public class AuthController {
 
     @Operation(summary = "Access Token, Refresh Token 재발급", description = "Refresh Token을 이용해 Access Token과 Refresh Token을 재발급합니다.")
     @PostMapping("/reissue")
-    public ApiResponse<CustomBody<AuthToken>> reissue(@Parameter(hidden = true) @MemberToken String token) {
+    public ApiResponse<CustomBody<AuthToken>> reissue(
+            @Parameter(hidden = true)
+            @MemberToken String token
+    ) {
         AuthToken authToken = authService.reissue(token);
         return ApiResponseGenerator.success(authToken, HttpStatus.OK);
     }

--- a/src/main/java/econo/buddybridge/auth/jwt/exception/JwtErrorCode.java
+++ b/src/main/java/econo/buddybridge/auth/jwt/exception/JwtErrorCode.java
@@ -8,7 +8,7 @@ public enum JwtErrorCode implements ErrorCode {
     INVALID_REFRESH_TOKEN("JW002", HttpStatus.UNAUTHORIZED, "올바른 REFRESH 토큰이 아닙니다."),
     EXPIRED_TOKEN("JW003", HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
     MISSING_TOKEN("JW004", HttpStatus.UNAUTHORIZED, "요청에 토큰이 포함되어있지 않습니다."),
-    LOGGED_OUT_TOKEN("JW005", HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다. 다시 로그인해주세요."),
+    LOGGED_OUT_TOKEN("JW005", HttpStatus.UNAUTHORIZED, "이미 로그아웃된 상태입니다."),
     ;
 
     private final String code;

--- a/src/main/java/econo/buddybridge/auth/jwt/exception/JwtErrorCode.java
+++ b/src/main/java/econo/buddybridge/auth/jwt/exception/JwtErrorCode.java
@@ -8,6 +8,7 @@ public enum JwtErrorCode implements ErrorCode {
     INVALID_REFRESH_TOKEN("JW002", HttpStatus.UNAUTHORIZED, "올바른 REFRESH 토큰이 아닙니다."),
     EXPIRED_TOKEN("JW003", HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
     MISSING_TOKEN("JW004", HttpStatus.UNAUTHORIZED, "요청에 토큰이 포함되어있지 않습니다."),
+    LOGGED_OUT_TOKEN("JW005", HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다. 다시 로그인해주세요."),
     ;
 
     private final String code;

--- a/src/main/java/econo/buddybridge/auth/jwt/exception/JwtErrorCode.java
+++ b/src/main/java/econo/buddybridge/auth/jwt/exception/JwtErrorCode.java
@@ -6,8 +6,8 @@ import org.springframework.http.HttpStatus;
 public enum JwtErrorCode implements ErrorCode {
     INVALID_ACCESS_TOKEN("JW001", HttpStatus.UNAUTHORIZED, "올바른 ACCESS 토큰이 아닙니다."),
     INVALID_REFRESH_TOKEN("JW002", HttpStatus.UNAUTHORIZED, "올바른 REFRESH 토큰이 아닙니다."),
-    EXPIRED_TOKEN("JW002", HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
-    MISSING_TOKEN("JW003", HttpStatus.UNAUTHORIZED, "요청에 토큰이 포함되어있지 않습니다."),
+    EXPIRED_TOKEN("JW003", HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+    MISSING_TOKEN("JW004", HttpStatus.UNAUTHORIZED, "요청에 토큰이 포함되어있지 않습니다."),
     ;
 
     private final String code;

--- a/src/main/java/econo/buddybridge/auth/jwt/exception/LoggedOutTokenException.java
+++ b/src/main/java/econo/buddybridge/auth/jwt/exception/LoggedOutTokenException.java
@@ -1,0 +1,12 @@
+package econo.buddybridge.auth.jwt.exception;
+
+import econo.buddybridge.common.exception.BusinessException;
+
+public class LoggedOutTokenException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new LoggedOutTokenException();
+
+    private LoggedOutTokenException() {
+        super(JwtErrorCode.LOGGED_OUT_TOKEN);
+    }
+}

--- a/src/main/java/econo/buddybridge/auth/jwt/service/AuthTokenService.java
+++ b/src/main/java/econo/buddybridge/auth/jwt/service/AuthTokenService.java
@@ -36,4 +36,9 @@ public class AuthTokenService {
 
         return generateAuthToken(memberId);
     }
+
+    @Transactional
+    public void logout(Long memberId) {
+        jwtTokenProvider.deleteByMemberId(memberId);
+    }
 }

--- a/src/main/java/econo/buddybridge/auth/jwt/service/JwtTokenProvider.java
+++ b/src/main/java/econo/buddybridge/auth/jwt/service/JwtTokenProvider.java
@@ -9,6 +9,7 @@ import econo.buddybridge.auth.jwt.exception.LoggedOutTokenException;
 import econo.buddybridge.auth.jwt.exception.MissingTokenException;
 import econo.buddybridge.auth.jwt.repository.TokenRepository;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
@@ -94,15 +95,7 @@ public class JwtTokenProvider {
     }
 
     public boolean validateToken(String token, TokenType tokenType) {
-        // Todo : 토큰 만료 시간이 지났는데 parseClaims가 호출되어 토큰 만료가 아닌 올바른 토큰이 아니라는 예외 발생
-        Claims claims = parseClaims(token, tokenType);
-
-        // Todo : parseClaims에서 JWT 라이브러리가 발생시키는 예외를 catch에서 잡기
-        Date expiration = claims.getExpiration();
-        if (expiration.before(new Date())) {
-            throw ExpiredTokenException.EXCEPTION;
-        }
-
+        parseClaims(token, tokenType);
         return true;
     }
 
@@ -118,7 +111,9 @@ public class JwtTokenProvider {
                     .build()
                     .parseSignedClaims(token)
                     .getPayload();
-        } catch (Exception e) { // Todo : 구체적인 예외 잡고, Exception으로 넘어가기
+        } catch (ExpiredJwtException e) {
+            throw ExpiredTokenException.EXCEPTION;
+        } catch (Exception e) {
             if (tokenType.equals(TokenType.ACCESS)) {
                 throw InvalidAccessTokenException.EXCEPTION;
             }

--- a/src/main/java/econo/buddybridge/auth/jwt/service/JwtTokenProvider.java
+++ b/src/main/java/econo/buddybridge/auth/jwt/service/JwtTokenProvider.java
@@ -94,8 +94,8 @@ public class JwtTokenProvider {
         return Optional.of(header.substring(BEARER_PREFIX.length()));
     }
 
-    public boolean validateToken(String token, TokenType tokenType) {
-        parseClaims(token, tokenType);
+    public boolean validateRefreshToken(String token) {
+        parseClaims(token, TokenType.REFRESH);
         return true;
     }
 
@@ -125,13 +125,10 @@ public class JwtTokenProvider {
         tokenRepository.deleteById(memberId);
     }
 
-    public void validateRefreshTokenExistsByMemberId(Long memberId) {
+    public boolean existsByMemberIdOrThrow(Long memberId) {
         if (!tokenRepository.existsById(memberId)) {
             throw LoggedOutTokenException.EXCEPTION;
         }
-    }
-
-    public boolean existsByMemberId(Long memberId) {
         return tokenRepository.existsById(memberId);
     }
 }

--- a/src/main/java/econo/buddybridge/auth/jwt/service/JwtTokenProvider.java
+++ b/src/main/java/econo/buddybridge/auth/jwt/service/JwtTokenProvider.java
@@ -125,7 +125,7 @@ public class JwtTokenProvider {
         tokenRepository.deleteById(memberId);
     }
 
-    public void existsByMemberId(Long memberId) {
+    public void validateRefreshTokenExistsByMemberId(Long memberId) {
         if (!tokenRepository.existsById(memberId)) {
             throw LoggedOutTokenException.EXCEPTION;
         }

--- a/src/main/java/econo/buddybridge/auth/jwt/service/JwtTokenProvider.java
+++ b/src/main/java/econo/buddybridge/auth/jwt/service/JwtTokenProvider.java
@@ -5,17 +5,19 @@ import econo.buddybridge.auth.jwt.TokenType;
 import econo.buddybridge.auth.jwt.exception.ExpiredTokenException;
 import econo.buddybridge.auth.jwt.exception.InvalidAccessTokenException;
 import econo.buddybridge.auth.jwt.exception.InvalidRefreshTokenException;
+import econo.buddybridge.auth.jwt.exception.LoggedOutTokenException;
 import econo.buddybridge.auth.jwt.exception.MissingTokenException;
 import econo.buddybridge.auth.jwt.repository.TokenRepository;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
 import java.time.Duration;
 import java.util.Date;
 import java.util.Optional;
-import javax.crypto.SecretKey;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
 
 @Component
 public class JwtTokenProvider {
@@ -92,8 +94,10 @@ public class JwtTokenProvider {
     }
 
     public boolean validateToken(String token, TokenType tokenType) {
+        // Todo : 토큰 만료 시간이 지났는데 parseClaims가 호출되어 토큰 만료가 아닌 올바른 토큰이 아니라는 예외 발생
         Claims claims = parseClaims(token, tokenType);
 
+        // Todo : parseClaims에서 JWT 라이브러리가 발생시키는 예외를 catch에서 잡기
         Date expiration = claims.getExpiration();
         if (expiration.before(new Date())) {
             throw ExpiredTokenException.EXCEPTION;
@@ -114,11 +118,21 @@ public class JwtTokenProvider {
                     .build()
                     .parseSignedClaims(token)
                     .getPayload();
-        } catch (Exception e) {
+        } catch (Exception e) { // Todo : 구체적인 예외 잡고, Exception으로 넘어가기
             if (tokenType.equals(TokenType.ACCESS)) {
                 throw InvalidAccessTokenException.EXCEPTION;
             }
             throw InvalidRefreshTokenException.EXCEPTION;
+        }
+    }
+
+    public void deleteByMemberId(Long memberId) {
+        tokenRepository.deleteById(memberId);
+    }
+
+    public void existsByMemberId(Long memberId) {
+        if (!tokenRepository.existsById(memberId)) {
+            throw LoggedOutTokenException.EXCEPTION;
         }
     }
 }

--- a/src/main/java/econo/buddybridge/auth/jwt/service/JwtTokenProvider.java
+++ b/src/main/java/econo/buddybridge/auth/jwt/service/JwtTokenProvider.java
@@ -130,4 +130,8 @@ public class JwtTokenProvider {
             throw LoggedOutTokenException.EXCEPTION;
         }
     }
+
+    public boolean existsByMemberId(Long memberId) {
+        return tokenRepository.existsById(memberId);
+    }
 }

--- a/src/main/java/econo/buddybridge/auth/service/AuthService.java
+++ b/src/main/java/econo/buddybridge/auth/service/AuthService.java
@@ -33,4 +33,9 @@ public class AuthService {
     public AuthToken reissue(String refreshToken) {
         return authTokenService.reissue(refreshToken);
     }
+
+    @Transactional
+    public void logout(Long memberId) {
+        authTokenService.logout(memberId);
+    }
 }

--- a/src/main/java/econo/buddybridge/chat/chatmessage/controller/ChatMessageController.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/controller/ChatMessageController.java
@@ -1,29 +1,33 @@
 package econo.buddybridge.chat.chatmessage.controller;
 
+import econo.buddybridge.auth.jwt.service.JwtTokenProvider;
 import econo.buddybridge.chat.chatmessage.dto.ChatMessageReqDto;
 import econo.buddybridge.chat.chatmessage.dto.ChatMessageResDto;
 import econo.buddybridge.chat.chatmessage.service.ChatMessageService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.messaging.handler.annotation.*;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
 public class ChatMessageController {
 
     private final ChatMessageService chatMessageService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @MessageMapping("/chat/{matching-id}") // 메시지 보내기 // /api/app/chat/{room-id} - pub
     @SendTo("/api/queue/chat/{matching-id}") // 구독 경로 - sub
     public ChatMessageResDto sendMessage(
             @DestinationVariable("matching-id") Long matchingId,
             @Payload ChatMessageReqDto chatMessageReqDto,
-            @Header("simpSessionAttributes") Map<String, Object> attributes
+            @Header("Authorization") String token
     ) {
-        Object memberIdObject = attributes.get("memberId");
-        Long senderId = Long.parseLong(memberIdObject.toString());
+        String accessToken = jwtTokenProvider.extractToken(token);
+        Long senderId = jwtTokenProvider.getMemberIdFromAccessToken(accessToken);
         return chatMessageService.save(senderId, chatMessageReqDto, matchingId);
     }
 }

--- a/src/main/java/econo/buddybridge/chat/chatmessage/controller/ChatMessageController.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/controller/ChatMessageController.java
@@ -24,9 +24,9 @@ public class ChatMessageController {
     public ChatMessageResDto sendMessage(
             @DestinationVariable("matching-id") Long matchingId,
             @Payload ChatMessageReqDto chatMessageReqDto,
-            @Header("Authorization") String token
+            @Header("Authorization") String header
     ) {
-        String accessToken = jwtTokenProvider.extractToken(token);
+        String accessToken = jwtTokenProvider.extractToken(header);
         Long senderId = jwtTokenProvider.getMemberIdFromAccessToken(accessToken);
         return chatMessageService.save(senderId, chatMessageReqDto, matchingId);
     }

--- a/src/main/java/econo/buddybridge/config/JwtInterceptor.java
+++ b/src/main/java/econo/buddybridge/config/JwtInterceptor.java
@@ -39,14 +39,14 @@ public class JwtInterceptor implements HandlerInterceptor {
 
         String token = jwtTokenProvider.extractToken(request.getHeader(HttpHeaders.AUTHORIZATION));
 
+        // Access Token에서 memberId 추출 후 Refresh Token이 tokenRepository에 존재하는지 확인
+        Long memberId = jwtTokenProvider.getMemberIdFromAccessToken(token);
+        jwtTokenProvider.existsByMemberId(memberId);
+
         // reissue 엔드포인트로 요청이 들어오면 refresh token 검증
         if (request.getRequestURI().contains("/reissue")) {
             return jwtTokenProvider.validateToken(token, TokenType.REFRESH);
         }
-
-        // Access Token에서 memberId 추출 후 Refresh Token이 tokenRepository에 존재하는지 확인
-        Long memberId = jwtTokenProvider.getMemberIdFromAccessToken(token);
-        jwtTokenProvider.existsByMemberId(memberId);
 
         return jwtTokenProvider.validateToken(token, TokenType.ACCESS);
     }

--- a/src/main/java/econo/buddybridge/config/JwtInterceptor.java
+++ b/src/main/java/econo/buddybridge/config/JwtInterceptor.java
@@ -48,6 +48,6 @@ public class JwtInterceptor implements HandlerInterceptor {
             return jwtTokenProvider.validateToken(token, TokenType.REFRESH);
         }
 
-        return jwtTokenProvider.validateToken(token, TokenType.ACCESS);
+        return jwtTokenProvider.existsByMemberId(memberId);
     }
 }

--- a/src/main/java/econo/buddybridge/config/JwtInterceptor.java
+++ b/src/main/java/econo/buddybridge/config/JwtInterceptor.java
@@ -44,6 +44,10 @@ public class JwtInterceptor implements HandlerInterceptor {
             return jwtTokenProvider.validateToken(token, TokenType.REFRESH);
         }
 
+        // Access Token에서 memberId 추출 후 Refresh Token이 tokenRepository에 존재하는지 확인
+        Long memberId = jwtTokenProvider.getMemberIdFromAccessToken(token);
+        jwtTokenProvider.existsByMemberId(memberId);
+
         return jwtTokenProvider.validateToken(token, TokenType.ACCESS);
     }
 }

--- a/src/main/java/econo/buddybridge/config/JwtInterceptor.java
+++ b/src/main/java/econo/buddybridge/config/JwtInterceptor.java
@@ -1,6 +1,5 @@
 package econo.buddybridge.config;
 
-import econo.buddybridge.auth.jwt.TokenType;
 import econo.buddybridge.auth.jwt.service.JwtTokenProvider;
 import econo.buddybridge.common.annotation.AllowAnonymous;
 import jakarta.servlet.http.HttpServletRequest;
@@ -18,6 +17,8 @@ import org.springframework.web.servlet.HandlerInterceptor;
 @Component
 @RequiredArgsConstructor
 public class JwtInterceptor implements HandlerInterceptor {
+
+    private static final String REISSUE_URI = "/api/auth/reissue";
 
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -39,15 +40,13 @@ public class JwtInterceptor implements HandlerInterceptor {
 
         String token = jwtTokenProvider.extractToken(request.getHeader(HttpHeaders.AUTHORIZATION));
 
-        // Access Token에서 memberId 추출 후 Refresh Token이 tokenRepository에 존재하는지 확인
-        Long memberId = jwtTokenProvider.getMemberIdFromAccessToken(token);
-        jwtTokenProvider.validateRefreshTokenExistsByMemberId(memberId);
-
         // reissue 엔드포인트로 요청이 들어오면 refresh token 검증
-        if (request.getRequestURI().contains("/reissue")) {
-            return jwtTokenProvider.validateToken(token, TokenType.REFRESH);
+        if (request.getRequestURI().equals(REISSUE_URI)) {
+            return jwtTokenProvider.validateRefreshToken(token);
         }
 
-        return jwtTokenProvider.existsByMemberId(memberId);
+        // Access Token에서 memberId 추출 후 Refresh Token이 tokenRepository에 존재하는지 확인
+        Long memberId = jwtTokenProvider.getMemberIdFromAccessToken(token);
+        return jwtTokenProvider.existsByMemberIdOrThrow(memberId);
     }
 }

--- a/src/main/java/econo/buddybridge/config/JwtInterceptor.java
+++ b/src/main/java/econo/buddybridge/config/JwtInterceptor.java
@@ -41,7 +41,7 @@ public class JwtInterceptor implements HandlerInterceptor {
 
         // Access Token에서 memberId 추출 후 Refresh Token이 tokenRepository에 존재하는지 확인
         Long memberId = jwtTokenProvider.getMemberIdFromAccessToken(token);
-        jwtTokenProvider.existsByMemberId(memberId);
+        jwtTokenProvider.validateRefreshTokenExistsByMemberId(memberId);
 
         // reissue 엔드포인트로 요청이 들어오면 refresh token 검증
         if (request.getRequestURI().contains("/reissue")) {


### PR DESCRIPTION
## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [X] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

JWT 방식 로그아웃 기능 구현
- `Redis`의 `RefreshToken`제거
- `ChatMessageController`에서 `Header`로 `Authorization : Bearer <AccessToken>` 받아오기

## 참고 사항

https://github.com/JNU-econovation/BuddyBridge_BE/pull/209 과 달라진점
[00f40c7](https://github.com/JNU-econovation/BuddyBridge_BE/pull/221/commits/00f40c7b5d5c99d04424cb925afe187beab3a662) 커밋으로 Stomp Interceptor 없이 `@Header`에서 `AccessToken`을 받아와 검증
다른 커밋들은 #209 에서 Cherry-pick한 커밋

## 관련 이슈

close #220 

## 체크리스트

- [X] 코드가 제대로 작동하는지 확인
- [X] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [X] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
