### PR TITLE
[HOTFIX] MyPageCommentResDto의 postStatus 필드 계산 후 반환

### DIFF
--- a/src/main/java/econo/buddybridge/comment/dto/MyPageCommentResDto.java
+++ b/src/main/java/econo/buddybridge/comment/dto/MyPageCommentResDto.java
@@ -5,8 +5,9 @@ import econo.buddybridge.member.entity.DisabilityType;
 import econo.buddybridge.post.entity.AssistanceType;
 import econo.buddybridge.post.entity.PostStatus;
 import econo.buddybridge.post.entity.PostType;
-import java.time.LocalDateTime;
 import lombok.Builder;
+
+import java.time.LocalDateTime;
 
 @Builder
 public record MyPageCommentResDto(

--- a/src/main/java/econo/buddybridge/comment/dto/MyPageCommentResDto.java
+++ b/src/main/java/econo/buddybridge/comment/dto/MyPageCommentResDto.java
@@ -3,6 +3,7 @@ package econo.buddybridge.comment.dto;
 import com.querydsl.core.annotations.QueryProjection;
 import econo.buddybridge.member.entity.DisabilityType;
 import econo.buddybridge.post.entity.AssistanceType;
+import econo.buddybridge.post.entity.PostStatus;
 import econo.buddybridge.post.entity.PostType;
 import lombok.Builder;
 
@@ -14,6 +15,7 @@ public record MyPageCommentResDto(
         Long commentId,
         Long postId,
         String postTitle,
+        PostStatus postStatus,
         PostType postType,
         DisabilityType disabilityType,
         AssistanceType assistanceType,

--- a/src/main/java/econo/buddybridge/comment/dto/MyPageCommentResDto.java
+++ b/src/main/java/econo/buddybridge/comment/dto/MyPageCommentResDto.java
@@ -3,7 +3,6 @@ package econo.buddybridge.comment.dto;
 import com.querydsl.core.annotations.QueryProjection;
 import econo.buddybridge.member.entity.DisabilityType;
 import econo.buddybridge.post.entity.AssistanceType;
-import econo.buddybridge.post.entity.PostStatus;
 import econo.buddybridge.post.entity.PostType;
 import lombok.Builder;
 
@@ -15,7 +14,6 @@ public record MyPageCommentResDto(
         Long commentId,
         Long postId,
         String postTitle,
-        PostStatus postStatus,
         PostType postType,
         DisabilityType disabilityType,
         AssistanceType assistanceType,

--- a/src/main/java/econo/buddybridge/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/econo/buddybridge/comment/repository/CommentRepositoryImpl.java
@@ -1,9 +1,5 @@
 package econo.buddybridge.comment.repository;
 
-import static econo.buddybridge.comment.entity.QComment.comment;
-import static econo.buddybridge.post.entity.QPost.post;
-import static org.springframework.data.domain.Sort.Order;
-
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -17,9 +13,14 @@ import econo.buddybridge.comment.dto.QCommentResDto;
 import econo.buddybridge.comment.dto.QMyPageCommentResDto;
 import econo.buddybridge.post.entity.Post;
 import econo.buddybridge.post.entity.PostType;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static econo.buddybridge.comment.entity.QComment.comment;
+import static econo.buddybridge.post.entity.QPost.post;
+import static org.springframework.data.domain.Sort.Order;
 
 @RequiredArgsConstructor
 public class CommentRepositoryImpl implements CommentRepositoryCustom {
@@ -72,7 +73,6 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                         comment.id,
                         comment.post.id,
                         comment.post.title,
-                        comment.post.postStatus,
                         comment.post.postType,
                         comment.post.disabilityType,
                         comment.post.assistanceType,
@@ -87,17 +87,18 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                 .limit(size)
                 .offset((long) page * size)
                 .fetch();
+//        List<MyPageCommentResDto> content = Collections.emptyList();
 
         // 댓글 단 게시글 수 조회
-        Long totalElements = queryFactory
-                .select(comment.id.count())
-                .from(comment)
-                .where(
-                        buildPostTypeExpression(postType),
-                        comment.author.id.eq(memberId)
-                )
-                .fetchOne();
-
+//        Long totalElements = queryFactory
+//                .select(comment.id.count())
+//                .from(comment)
+//                .where(
+//                        buildPostTypeExpression(postType),
+//                        comment.author.id.eq(memberId)
+//                )
+//                .fetchOne();
+        Long totalElements = 0L;
         return new MyPageCommentCustomPage(content, totalElements, content.size() < size);
     }
 

--- a/src/main/java/econo/buddybridge/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/econo/buddybridge/comment/repository/CommentRepositoryImpl.java
@@ -3,6 +3,7 @@ package econo.buddybridge.comment.repository;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import econo.buddybridge.comment.dto.CommentCustomPage;
 import econo.buddybridge.comment.dto.CommentResDto;
@@ -11,12 +12,17 @@ import econo.buddybridge.comment.dto.MyPageCommentResDto;
 import econo.buddybridge.comment.dto.QAuthorDto;
 import econo.buddybridge.comment.dto.QCommentResDto;
 import econo.buddybridge.comment.dto.QMyPageCommentResDto;
+import econo.buddybridge.matching.entity.Matching;
 import econo.buddybridge.post.entity.Post;
+import econo.buddybridge.post.entity.PostStatus;
 import econo.buddybridge.post.entity.PostType;
+import econo.buddybridge.post.repository.PostRepositoryImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static econo.buddybridge.comment.entity.QComment.comment;
 import static econo.buddybridge.post.entity.QPost.post;
@@ -26,6 +32,7 @@ import static org.springframework.data.domain.Sort.Order;
 public class CommentRepositoryImpl implements CommentRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+    private final PostRepositoryImpl postRepositoryImpl;
 
     @Override
     public CommentCustomPage findByPost(Post post, Long cursor, Pageable page) {
@@ -73,6 +80,7 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                         comment.id,
                         comment.post.id,
                         comment.post.title,
+                        Expressions.constant(PostStatus.RECRUITING),
                         comment.post.postType,
                         comment.post.disabilityType,
                         comment.post.assistanceType,
@@ -88,6 +96,15 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                 .offset((long) page * size)
                 .fetch();
 
+        // 해당하는 게시글 ID 리스트 조회
+        List<Long> postIds = content.stream().map(MyPageCommentResDto::postId).toList();
+
+        // 각 게시글 ID에 대해 전체 매칭 조회
+        Map<Long, List<Matching>> postMatchings = postRepositoryImpl.getMatchings(postIds);
+
+        // content를 순환하면서 각 게시글의 해당하는 postStatus 설정
+        List<MyPageCommentResDto> updatedContent = updatePostStatusInContent(content, postMatchings);
+
         // 댓글 단 게시글 수 조회
         Long totalElements = queryFactory
                 .select(comment.id.count())
@@ -98,7 +115,26 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                 )
                 .fetchOne();
 
-        return new MyPageCommentCustomPage(content, totalElements, content.size() < size);
+        return new MyPageCommentCustomPage(updatedContent, totalElements, content.size() < size);
+    }
+
+    private List<MyPageCommentResDto> updatePostStatusInContent(List<MyPageCommentResDto> content, Map<Long, List<Matching>> postMatchings) {
+        return content.stream()
+                .map(comment -> {
+                    List<Matching> matchings = postMatchings.getOrDefault(comment.postId(), Collections.emptyList());
+                    PostStatus status = postRepositoryImpl.calculatePostStatus(matchings);
+                    return MyPageCommentResDto.builder()
+                            .content(comment.content())
+                            .commentId(comment.commentId())
+                            .postId(comment.postId())
+                            .postTitle(comment.postTitle())
+                            .postStatus(status)
+                            .postType(comment.postType())
+                            .disabilityType(comment.disabilityType())
+                            .assistanceType(comment.assistanceType())
+                            .postCreatedAt(comment.postCreatedAt())
+                            .build();
+                }).toList();
     }
 
     private BooleanExpression buildPostTypeExpression(PostType postType) {

--- a/src/main/java/econo/buddybridge/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/econo/buddybridge/comment/repository/CommentRepositoryImpl.java
@@ -87,18 +87,17 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                 .limit(size)
                 .offset((long) page * size)
                 .fetch();
-//        List<MyPageCommentResDto> content = Collections.emptyList();
 
         // 댓글 단 게시글 수 조회
-//        Long totalElements = queryFactory
-//                .select(comment.id.count())
-//                .from(comment)
-//                .where(
-//                        buildPostTypeExpression(postType),
-//                        comment.author.id.eq(memberId)
-//                )
-//                .fetchOne();
-        Long totalElements = 0L;
+        Long totalElements = queryFactory
+                .select(comment.id.count())
+                .from(comment)
+                .where(
+                        buildPostTypeExpression(postType),
+                        comment.author.id.eq(memberId)
+                )
+                .fetchOne();
+
         return new MyPageCommentCustomPage(content, totalElements, content.size() < size);
     }
 

--- a/src/main/java/econo/buddybridge/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/econo/buddybridge/post/repository/PostRepositoryImpl.java
@@ -185,7 +185,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .toList();
     }
 
-    private PostStatus calculatePostStatus(List<Matching> matchings) {
+    public PostStatus calculatePostStatus(List<Matching> matchings) {
         return matchings
                 .stream()
                 .anyMatch(m -> m.getMatchingStatus() == MatchingStatus.DONE)
@@ -193,7 +193,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 : PostStatus.RECRUITING;
     }
 
-    private Map<Long, List<Matching>> getMatchings(List<Long> postIds) {
+    public Map<Long, List<Matching>> getMatchings(List<Long> postIds) {
         return queryFactory
                 .selectFrom(matching)
                 .where(matching.post.id.in(postIds))


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

문제 : `Post` Entity에서 postStatus 필드 제거
-> `MyPageCommentResDto`에서 `postStatus` 필드 사용
-> `CommentRepositoryImpl`에서 QueryDsl을 사용하는 Q객체 필드 에러 발생

해결 : `CommentRepositoryImpl`에서 `postStatus` 계산 후 반환

## 관련 이슈

close #228 

## 체크리스트

- [X] 코드가 제대로 작동하는지 확인
- [X] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [X] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
