### PR TITLE
[FEAT] 신고하기 API 구현

### DIFF
--- a/src/main/java/econo/buddybridge/chat/chatmessage/service/ChatMessageService.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/service/ChatMessageService.java
@@ -6,7 +6,6 @@ import static econo.buddybridge.common.consts.BuddyBridgeStatic.CHAT_NOTIFICATIO
 import econo.buddybridge.chat.chatmessage.dto.ChatMessageReqDto;
 import econo.buddybridge.chat.chatmessage.dto.ChatMessageResDto;
 import econo.buddybridge.chat.chatmessage.entity.ChatMessage;
-import econo.buddybridge.chat.chatmessage.exception.LastChatMessageNotFoundException;
 import econo.buddybridge.chat.chatmessage.repository.ChatMessageRepository;
 import econo.buddybridge.matching.entity.Matching;
 import econo.buddybridge.matching.exception.MatchingUnauthorizedAccessException;
@@ -15,9 +14,7 @@ import econo.buddybridge.member.entity.Member;
 import econo.buddybridge.member.service.MemberService;
 import econo.buddybridge.notification.entity.NotificationType;
 import econo.buddybridge.notification.service.EmitterService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -74,23 +71,5 @@ public class ChatMessageService {
         } else {
             throw MatchingUnauthorizedAccessException.EXCEPTION;
         }
-    }
-
-    @Transactional // 마지막 메시지 조회
-    public ChatMessageResDto getLastChatMessage(Long matchingId) {
-        List<ChatMessage> chatMessageList = chatMessageRepository.findLastMessageByMatchingId(matchingId, PageRequest.of(0, 1));
-        if (chatMessageList.isEmpty()) {
-            throw LastChatMessageNotFoundException.EXCEPTION;
-        }
-
-        ChatMessage chatMessage = chatMessageList.getFirst();
-
-        return ChatMessageResDto.builder()
-                .messageId(chatMessage.getId())
-                .senderId(chatMessage.getSender().getId()) // senderId 받아오기
-                .content(chatMessage.getContent())
-                .messageType(chatMessage.getMessageType())
-                .createdAt(chatMessage.getCreatedAt())
-                .build();
     }
 }

--- a/src/main/java/econo/buddybridge/comment/entity/Comment.java
+++ b/src/main/java/econo/buddybridge/comment/entity/Comment.java
@@ -1,6 +1,6 @@
 package econo.buddybridge.comment.entity;
 
-import econo.buddybridge.common.persistence.BaseEntity;
+import econo.buddybridge.common.persistence.SoftDeletableEntity;
 import econo.buddybridge.member.entity.Member;
 import econo.buddybridge.post.entity.Post;
 import jakarta.persistence.Column;
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(name = "COMMENT")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Comment extends BaseEntity {
+public class Comment extends SoftDeletableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,11 +31,11 @@ public class Comment extends BaseEntity {
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="post_id")
+    @JoinColumn(name = "post_id")
     private Post post;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="author_id")
+    @JoinColumn(name = "author_id")
     private Member author;
 
     @Builder

--- a/src/main/java/econo/buddybridge/comment/event/CommentDeleteEvent.java
+++ b/src/main/java/econo/buddybridge/comment/event/CommentDeleteEvent.java
@@ -1,0 +1,18 @@
+package econo.buddybridge.comment.event;
+
+import econo.buddybridge.comment.entity.Comment;
+import econo.buddybridge.common.event.DomainEvent;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommentDeleteEvent extends DomainEvent {
+
+    private final Comment comment;
+
+    public static CommentDeleteEvent from(Comment comment) {
+        return new CommentDeleteEvent(comment);
+    }
+}

--- a/src/main/java/econo/buddybridge/comment/event/handler/CommentDeleteEventHandler.java
+++ b/src/main/java/econo/buddybridge/comment/event/handler/CommentDeleteEventHandler.java
@@ -1,0 +1,29 @@
+package econo.buddybridge.comment.event.handler;
+
+import econo.buddybridge.comment.entity.Comment;
+import econo.buddybridge.comment.event.CommentDeleteEvent;
+import econo.buddybridge.comment.repository.CommentRepository;
+import econo.buddybridge.report.repository.CommentReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class CommentDeleteEventHandler {
+
+    private final CommentReportRepository commentReportRepository;
+    private final CommentRepository commentRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleCommentDeleteEvent(CommentDeleteEvent event) {
+        Comment comment = event.getComment();
+
+        if (commentReportRepository.existsByReportedComment(comment)) {
+            comment.delete();
+        } else {
+            commentRepository.delete(comment);
+        }
+    }
+}

--- a/src/main/java/econo/buddybridge/comment/exception/CommentErrorCode.java
+++ b/src/main/java/econo/buddybridge/comment/exception/CommentErrorCode.java
@@ -10,6 +10,7 @@ public enum CommentErrorCode implements ErrorCode {
     COMMENT_INVALID_DIRECTION("C004", HttpStatus.BAD_REQUEST, "올바르지 않은 정렬 방식입니다."),
     COMMENT_ALREADY_WRITTEN("C005", HttpStatus.BAD_REQUEST, "이미 댓글을 작성했습니다. 댓글은 하나만 작성할 수 있습니다."),
     COMMENT_SAME_GENDER_ONLY("C006", HttpStatus.BAD_REQUEST, "이성간 댓글을 작성할 수 없습니다."),
+    COMMENT_SELF_NOT_ALLOWED("C007", HttpStatus.BAD_REQUEST, "본인의 글에는 댓글을 작성할 수 없습니다."),
     ;
 
     private final String code;

--- a/src/main/java/econo/buddybridge/comment/exception/CommentSelfNotAllowedException.java
+++ b/src/main/java/econo/buddybridge/comment/exception/CommentSelfNotAllowedException.java
@@ -1,0 +1,12 @@
+package econo.buddybridge.comment.exception;
+
+import econo.buddybridge.common.exception.BusinessException;
+
+public class CommentSelfNotAllowedException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new CommentSelfNotAllowedException();
+
+    private CommentSelfNotAllowedException() {
+        super(CommentErrorCode.COMMENT_SELF_NOT_ALLOWED);
+    }
+}

--- a/src/main/java/econo/buddybridge/comment/repository/CommentRepository.java
+++ b/src/main/java/econo/buddybridge/comment/repository/CommentRepository.java
@@ -14,4 +14,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, Comment
 
     @Query("SELECT c FROM Comment c JOIN FETCH c.author WHERE c.id = :commentId")
     Optional<Comment> findByIdWithAuthor(@Param("commentId") Long commentId);
+
+    @Override
+    @Query("SELECT c FROM Comment c WHERE c.id = :commentId")
+    Optional<Comment> findById(@Param("commentId") Long commentId);
 }

--- a/src/main/java/econo/buddybridge/comment/repository/CommentRepository.java
+++ b/src/main/java/econo/buddybridge/comment/repository/CommentRepository.java
@@ -3,9 +3,15 @@ package econo.buddybridge.comment.repository;
 import econo.buddybridge.comment.entity.Comment;
 import econo.buddybridge.member.entity.Member;
 import econo.buddybridge.post.entity.Post;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
 
     boolean existsByPostAndAuthor(Post post, Member author);
+
+    @Query("SELECT c FROM Comment c JOIN FETCH c.author WHERE c.id = :commentId")
+    Optional<Comment> findByIdWithAuthor(@Param("commentId") Long commentId);
 }

--- a/src/main/java/econo/buddybridge/comment/service/CommentService.java
+++ b/src/main/java/econo/buddybridge/comment/service/CommentService.java
@@ -4,6 +4,7 @@ import econo.buddybridge.comment.dto.CommentCustomPage;
 import econo.buddybridge.comment.dto.CommentReqDto;
 import econo.buddybridge.comment.dto.MyPageCommentCustomPage;
 import econo.buddybridge.comment.entity.Comment;
+import econo.buddybridge.comment.event.CommentDeleteEvent;
 import econo.buddybridge.comment.exception.CommentAlreadyWrittenException;
 import econo.buddybridge.comment.exception.CommentDeleteNotAllowedException;
 import econo.buddybridge.comment.exception.CommentInvalidDirectionException;
@@ -20,6 +21,7 @@ import econo.buddybridge.post.entity.Post;
 import econo.buddybridge.post.entity.PostType;
 import econo.buddybridge.post.service.PostService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
@@ -37,6 +39,7 @@ public class CommentService {
     private final PostService postService;
     private final CommentRepository commentRepository;
     private final EmitterService emitterService;
+    private final ApplicationEventPublisher publisher;
 
     @Transactional(readOnly = true) // MyPage 댓글 조회
     public MyPageCommentCustomPage getMyPageComments(Long memberId, Integer page, Integer size, String sort, PostType postType) {
@@ -116,7 +119,7 @@ public class CommentService {
             throw CommentDeleteNotAllowedException.EXCEPTION;
         }
 
-        commentRepository.delete(comment);
+        publisher.publishEvent(CommentDeleteEvent.from(comment));
     }
 
     private Comment findCommentByIdOrThrow(Long commentId) {

--- a/src/main/java/econo/buddybridge/comment/service/CommentService.java
+++ b/src/main/java/econo/buddybridge/comment/service/CommentService.java
@@ -118,6 +118,12 @@ public class CommentService {
                 .orElseThrow(() -> CommentNotFoundException.EXCEPTION);
     }
 
+    @Transactional(readOnly = true) // 댓글 조회
+    public Comment findCommentByIdWithAuthorOrThrow(Long commentId) {
+        return commentRepository.findByIdWithAuthor(commentId)
+                .orElseThrow(() -> CommentNotFoundException.EXCEPTION);
+    }
+
     private Comment commentReqToComment(CommentReqDto commentReqDto, Post post, Member member) {
         return Comment.builder()
                 .post(post)

--- a/src/main/java/econo/buddybridge/comment/service/CommentService.java
+++ b/src/main/java/econo/buddybridge/comment/service/CommentService.java
@@ -9,6 +9,7 @@ import econo.buddybridge.comment.exception.CommentDeleteNotAllowedException;
 import econo.buddybridge.comment.exception.CommentInvalidDirectionException;
 import econo.buddybridge.comment.exception.CommentNotFoundException;
 import econo.buddybridge.comment.exception.CommentSameGenderOnlyException;
+import econo.buddybridge.comment.exception.CommentSelfNotAllowedException;
 import econo.buddybridge.comment.exception.CommentUpdateNotAllowedException;
 import econo.buddybridge.comment.repository.CommentRepository;
 import econo.buddybridge.member.entity.Member;
@@ -60,22 +61,27 @@ public class CommentService {
 
     @Transactional  // 댓글 생성
     public Long createComment(CommentReqDto commentReqDto, Long postId, Long memberId) {
-        Member member = memberService.findMemberByIdOrThrow(memberId);
+        Member author = memberService.findMemberByIdOrThrow(memberId);
         Post post = postService.findPostByIdOrThrow(postId);
 
-        if (post.getGender() != member.getGender()) {
+        if (post.getGender() != author.getGender()) {
             throw CommentSameGenderOnlyException.EXCEPTION;
         }
 
+        // 본인의 게시글에 댓글 작성 불가
+        if (post.getAuthor().equals(author)) {
+            throw CommentSelfNotAllowedException.EXCEPTION;
+        }
+
         // 기존에 댓글을 작성한 적이 있는지 확인하고 있다면 댓글 작성 불가
-        if (commentRepository.existsByPostAndAuthor(post, member)) {
+        if (commentRepository.existsByPostAndAuthor(post, author)) {
             throw CommentAlreadyWrittenException.EXCEPTION;
         }
 
-        Comment comment = commentReqToComment(commentReqDto, post, member);
+        Comment comment = commentReqToComment(commentReqDto, post, author);
 
         // 게시글 작성자에게 댓글 알림 전송
-        sendNotificationToPostAuthor(member, comment, post);
+        sendNotificationToPostAuthor(author, comment, post);
 
         return commentRepository.save(comment).getId();
     }

--- a/src/main/java/econo/buddybridge/common/event/DomainEvent.java
+++ b/src/main/java/econo/buddybridge/common/event/DomainEvent.java
@@ -1,0 +1,14 @@
+package econo.buddybridge.common.event;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public abstract class DomainEvent {
+
+    private final LocalDateTime occurredAt;
+
+    protected DomainEvent() {
+        this.occurredAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/econo/buddybridge/common/persistence/BaseEntity.java
+++ b/src/main/java/econo/buddybridge/common/persistence/BaseEntity.java
@@ -4,7 +4,9 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -12,6 +14,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BaseEntity {
 
     @CreatedDate

--- a/src/main/java/econo/buddybridge/common/persistence/BaseEntity.java
+++ b/src/main/java/econo/buddybridge/common/persistence/BaseEntity.java
@@ -15,7 +15,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class BaseEntity {
+public abstract class BaseEntity {
 
     @CreatedDate
     @Column(nullable = false, updatable = false)

--- a/src/main/java/econo/buddybridge/common/persistence/SoftDeletableEntity.java
+++ b/src/main/java/econo/buddybridge/common/persistence/SoftDeletableEntity.java
@@ -1,0 +1,25 @@
+package econo.buddybridge.common.persistence;
+
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
+
+@MappedSuperclass
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FilterDef(name = "deletedFilter", parameters = @ParamDef(name = "isDeleted", type = boolean.class))
+@Filter(name = "deletedFilter", condition = "deleted = :isDeleted")
+public abstract class SoftDeletableEntity extends BaseEntity {
+
+    private boolean deleted = false;
+
+    private LocalDateTime deletedAt;
+
+    public void delete() {
+        this.deleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/econo/buddybridge/common/persistence/filter/SessionFilterManager.java
+++ b/src/main/java/econo/buddybridge/common/persistence/filter/SessionFilterManager.java
@@ -32,4 +32,15 @@ public class SessionFilterManager {
         Session session = entityManager.unwrap(Session.class);
         session.disableFilter(filter);
     }
+
+    /**
+     * 필터 활성화 여부 확인
+     *
+     * @param filter 확인할 필터
+     * @return 활성화 여부
+     */
+    public boolean isFilterEnabled(String filter) {
+        Session session = entityManager.unwrap(Session.class);
+        return session.getEnabledFilter(filter) != null;
+    }
 }

--- a/src/main/java/econo/buddybridge/common/persistence/filter/SessionFilterManager.java
+++ b/src/main/java/econo/buddybridge/common/persistence/filter/SessionFilterManager.java
@@ -1,0 +1,35 @@
+package econo.buddybridge.common.persistence.filter;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.Session;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SessionFilterManager {
+
+    private final EntityManager entityManager;
+
+    /**
+     * 필터 활성화
+     *
+     * @param filter 활성화 할 필터
+     * @param paramName 파라미터 이름
+     * @param paramValue 파라미터 값
+     */
+    public void enableFilter(String filter, String paramName, Object paramValue) {
+        Session session = entityManager.unwrap(Session.class);
+        session.enableFilter(filter).setParameter(paramName, paramValue);
+    }
+
+    /**
+     * 필터 비활성화
+     *
+     * @param filter 비활성화 할 필터
+     */
+    public void disableFilter(String filter) {
+        Session session = entityManager.unwrap(Session.class);
+        session.disableFilter(filter);
+    }
+}

--- a/src/main/java/econo/buddybridge/common/persistence/filter/annotation/WithDeletedContent.java
+++ b/src/main/java/econo/buddybridge/common/persistence/filter/annotation/WithDeletedContent.java
@@ -9,5 +9,4 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface WithDeletedContent {
     boolean value() default true;   // 삭제된 컨텐츠 포함 여부: true - 포함, false - 미포함
-    String filterName() default "deletedFilter";   // 사용할 필터 이름
 }

--- a/src/main/java/econo/buddybridge/common/persistence/filter/annotation/WithDeletedContent.java
+++ b/src/main/java/econo/buddybridge/common/persistence/filter/annotation/WithDeletedContent.java
@@ -1,0 +1,13 @@
+package econo.buddybridge.common.persistence.filter.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WithDeletedContent {
+    boolean value() default true;   // 삭제된 컨텐츠 포함 여부: true - 포함, false - 미포함
+    String filterName() default "deletedFilter";   // 사용할 필터 이름
+}

--- a/src/main/java/econo/buddybridge/common/persistence/filter/aspect/WithDeletedContentAspect.java
+++ b/src/main/java/econo/buddybridge/common/persistence/filter/aspect/WithDeletedContentAspect.java
@@ -29,6 +29,11 @@ public class WithDeletedContentAspect {
             return joinPoint.proceed();
         }
 
+        // 이미 활성화된 필터가 있는 경우
+        if (sessionFilterManager.isFilterEnabled(DELETED_FILTER)) {
+            return joinPoint.proceed();
+        }
+
         try {
             sessionFilterManager.enableFilter(DELETED_FILTER, DELETED_PARAM, false);
             return joinPoint.proceed();

--- a/src/main/java/econo/buddybridge/common/persistence/filter/aspect/WithDeletedContentAspect.java
+++ b/src/main/java/econo/buddybridge/common/persistence/filter/aspect/WithDeletedContentAspect.java
@@ -1,0 +1,39 @@
+package econo.buddybridge.common.persistence.filter.aspect;
+
+import econo.buddybridge.common.persistence.filter.SessionFilterManager;
+import econo.buddybridge.common.persistence.filter.annotation.WithDeletedContent;
+import java.lang.reflect.Method;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class WithDeletedContentAspect {
+
+    private static final String DELETED_FILTER = "deletedFilter";
+    private static final String DELETED_PARAM = "isDeleted";
+
+    private final SessionFilterManager sessionFilterManager;
+
+    @Around("execution(* econo.buddybridge.*.service.*Service.*(..))")
+    public Object handleFilter(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+
+        if (method.isAnnotationPresent(WithDeletedContent.class)) {
+            return joinPoint.proceed();
+        }
+
+        try {
+            sessionFilterManager.enableFilter(DELETED_FILTER, DELETED_PARAM, false);
+            return joinPoint.proceed();
+        } finally {
+            sessionFilterManager.disableFilter(DELETED_FILTER);
+        }
+    }
+}

--- a/src/main/java/econo/buddybridge/common/validation/EnumTypeValue.java
+++ b/src/main/java/econo/buddybridge/common/validation/EnumTypeValue.java
@@ -1,0 +1,22 @@
+package econo.buddybridge.common.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = EnumTypeValueValidator.class)
+public @interface EnumTypeValue {
+
+    String message() default "올바르지 않은 열거형 값입니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    Class<? extends ValueEnum<?>> enumClass();
+}

--- a/src/main/java/econo/buddybridge/common/validation/EnumTypeValueValidator.java
+++ b/src/main/java/econo/buddybridge/common/validation/EnumTypeValueValidator.java
@@ -1,0 +1,27 @@
+package econo.buddybridge.common.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.Arrays;
+
+public class EnumTypeValueValidator implements ConstraintValidator<EnumTypeValue, String> {
+
+    private ValueEnum<?>[] enumValues;
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return false;
+        }
+
+        return Arrays.stream(enumValues)
+                .map(ValueEnum::getValue)
+                .anyMatch(enumValue -> enumValue.equals(value));
+    }
+
+    @Override
+    public void initialize(EnumTypeValue constraintAnnotation) {
+        Class<? extends ValueEnum<?>> enumClass = constraintAnnotation.enumClass();
+        enumValues = enumClass.getEnumConstants();
+    }
+}

--- a/src/main/java/econo/buddybridge/common/validation/ValueEnum.java
+++ b/src/main/java/econo/buddybridge/common/validation/ValueEnum.java
@@ -1,0 +1,5 @@
+package econo.buddybridge.common.validation;
+
+public interface ValueEnum<T> {
+    T getValue();
+}

--- a/src/main/java/econo/buddybridge/matching/entity/Matching.java
+++ b/src/main/java/econo/buddybridge/matching/entity/Matching.java
@@ -1,7 +1,7 @@
 package econo.buddybridge.matching.entity;
 
 import econo.buddybridge.chat.chatmessage.entity.ChatMessage;
-import econo.buddybridge.common.persistence.BaseEntity;
+import econo.buddybridge.common.persistence.SoftDeletableEntity;
 import econo.buddybridge.member.entity.Member;
 import econo.buddybridge.post.entity.Post;
 import jakarta.persistence.CascadeType;
@@ -17,19 +17,18 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Entity
 @Getter
 @Table(name = "MATCHING")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Matching extends BaseEntity {
+public class Matching extends SoftDeletableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/econo/buddybridge/matching/event/MatchingDeleteEvent.java
+++ b/src/main/java/econo/buddybridge/matching/event/MatchingDeleteEvent.java
@@ -1,0 +1,18 @@
+package econo.buddybridge.matching.event;
+
+import econo.buddybridge.common.event.DomainEvent;
+import econo.buddybridge.matching.entity.Matching;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class MatchingDeleteEvent extends DomainEvent {
+
+    private final Matching matching;
+
+    public static MatchingDeleteEvent from(Matching matching) {
+        return new MatchingDeleteEvent(matching);
+    }
+}

--- a/src/main/java/econo/buddybridge/matching/event/handler/MatchingDeleteEventHandler.java
+++ b/src/main/java/econo/buddybridge/matching/event/handler/MatchingDeleteEventHandler.java
@@ -1,0 +1,29 @@
+package econo.buddybridge.matching.event.handler;
+
+import econo.buddybridge.matching.entity.Matching;
+import econo.buddybridge.matching.event.MatchingDeleteEvent;
+import econo.buddybridge.matching.repository.MatchingRepository;
+import econo.buddybridge.report.repository.MatchingReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class MatchingDeleteEventHandler {
+
+    private final MatchingReportRepository matchingReportRepository;
+    private final MatchingRepository matchingRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleCommentDeleteEvent(MatchingDeleteEvent event) {
+        Matching matching = event.getMatching();
+
+        if (matchingReportRepository.existsByReportedMatching(matching)) {
+            matching.delete();
+        } else {
+            matchingRepository.delete(matching);
+        }
+    }
+}

--- a/src/main/java/econo/buddybridge/matching/repository/MatchingRepository.java
+++ b/src/main/java/econo/buddybridge/matching/repository/MatchingRepository.java
@@ -1,11 +1,13 @@
 package econo.buddybridge.matching.repository;
 
 import econo.buddybridge.matching.entity.Matching;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.repository.query.Param;
 
 public interface MatchingRepository extends JpaRepository<Matching, Long> {
 
@@ -13,4 +15,10 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
     Optional<Matching> findByIdWithMembersAndPost(Long matchingId);
 
     List<Matching> findByPostId(Long postId);
+
+    @Query("SELECT COUNT(m) FROM Matching m WHERE m.post.id = :post_id AND m.matchingStatus = 'DONE'")
+    Integer countMatchingDoneByPostId(Long post_id);
+
+    @Query("SELECT m FROM Matching m JOIN FETCH m.giver JOIN FETCH m.taker WHERE m.id = :matchingId")
+    Optional<Matching> findByIdWithMembers(@Param("matchingId") Long matchingId);
 }

--- a/src/main/java/econo/buddybridge/matching/repository/MatchingRepository.java
+++ b/src/main/java/econo/buddybridge/matching/repository/MatchingRepository.java
@@ -1,12 +1,10 @@
 package econo.buddybridge.matching.repository;
 
 import econo.buddybridge.matching.entity.Matching;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.repository.query.Param;
 
 public interface MatchingRepository extends JpaRepository<Matching, Long> {

--- a/src/main/java/econo/buddybridge/matching/repository/MatchingRepository.java
+++ b/src/main/java/econo/buddybridge/matching/repository/MatchingRepository.java
@@ -16,9 +16,10 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
 
     List<Matching> findByPostId(Long postId);
 
-    @Query("SELECT COUNT(m) FROM Matching m WHERE m.post.id = :post_id AND m.matchingStatus = 'DONE'")
-    Integer countMatchingDoneByPostId(Long post_id);
-
     @Query("SELECT m FROM Matching m JOIN FETCH m.giver JOIN FETCH m.taker WHERE m.id = :matchingId")
     Optional<Matching> findByIdWithMembers(@Param("matchingId") Long matchingId);
+
+    @Override
+    @Query("SELECT m FROM Matching m WHERE m.id = :matchingId")
+    Optional<Matching> findById(@Param("matchingId") Long matchingId);
 }

--- a/src/main/java/econo/buddybridge/matching/service/MatchingRoomService.java
+++ b/src/main/java/econo/buddybridge/matching/service/MatchingRoomService.java
@@ -31,7 +31,7 @@ public class MatchingRoomService {
     private final MatchingService matchingService;
     private final NotificationService notificationService;
 
-    @Transactional
+    @Transactional(readOnly = true) // 매칭방 조회
     public MatchingCustomPage getMatchings(Long memberId, Integer size, LocalDateTime cursor, MatchingStatus matchingStatus) {
         PageRequest page = PageRequest.of(0, size);
         return matchingRepositoryCustom.findMatchings(memberId, size, cursor, matchingStatus, page);

--- a/src/main/java/econo/buddybridge/matching/service/MatchingService.java
+++ b/src/main/java/econo/buddybridge/matching/service/MatchingService.java
@@ -7,6 +7,7 @@ import econo.buddybridge.matching.dto.MatchingReqDto;
 import econo.buddybridge.matching.dto.MatchingUpdateDto;
 import econo.buddybridge.matching.entity.Matching;
 import econo.buddybridge.matching.entity.MatchingStatus;
+import econo.buddybridge.matching.event.MatchingDeleteEvent;
 import econo.buddybridge.matching.exception.MatchingCompletedException;
 import econo.buddybridge.matching.exception.MatchingNotFoundException;
 import econo.buddybridge.matching.repository.MatchingRepository;
@@ -17,6 +18,7 @@ import econo.buddybridge.post.entity.PostType;
 import econo.buddybridge.post.exception.PostUnauthorizedAccessException;
 import econo.buddybridge.post.service.PostService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +30,7 @@ public class MatchingService {
     private final MatchingRepository matchingRepository;
     private final MemberService memberService;
     private final PostService postService;
+    private final ApplicationEventPublisher publisher;
 
     // 존재하는 매칭인지 확인
     @Transactional(readOnly = true)
@@ -115,7 +118,7 @@ public class MatchingService {
         Member author = memberService.findMemberByIdOrThrow(memberId);
         validatePostAuthor(matching.getPost(), author);
 
-        matchingRepository.delete(matching);
+        publisher.publishEvent(MatchingDeleteEvent.from(matching));
     }
 
     // MatchingReqDto -> Matching

--- a/src/main/java/econo/buddybridge/matching/service/MatchingService.java
+++ b/src/main/java/econo/buddybridge/matching/service/MatchingService.java
@@ -37,6 +37,12 @@ public class MatchingService {
     }
 
     @Transactional(readOnly = true)
+    public Matching findMatchingByIdWithMembers(Long matchingId) {
+        return matchingRepository.findByIdWithMembers(matchingId)
+                .orElseThrow(() -> MatchingNotFoundException.EXCEPTION);
+    }
+
+    @Transactional(readOnly = true)
     public Matching findByIdWithMembersAndPost(Long matchingId) {
         return matchingRepository.findByIdWithMembersAndPost(matchingId)
                 .orElseThrow(() -> MatchingNotFoundException.EXCEPTION);

--- a/src/main/java/econo/buddybridge/post/entity/Post.java
+++ b/src/main/java/econo/buddybridge/post/entity/Post.java
@@ -2,7 +2,7 @@ package econo.buddybridge.post.entity;
 
 
 import econo.buddybridge.comment.entity.Comment;
-import econo.buddybridge.common.persistence.BaseEntity;
+import econo.buddybridge.common.persistence.SoftDeletableEntity;
 import econo.buddybridge.matching.entity.Matching;
 import econo.buddybridge.member.entity.DisabilityType;
 import econo.buddybridge.member.entity.Gender;
@@ -12,7 +12,6 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
@@ -23,16 +22,14 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -41,8 +38,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @DynamicUpdate
-@EntityListeners(value = AuditingEntityListener.class)
-public class Post extends BaseEntity {
+public class Post extends SoftDeletableEntity {
 
     @Id
     @Column(name = "post_id")
@@ -104,7 +100,8 @@ public class Post extends BaseEntity {
         if (postUpdateReqDto.assistanceStartTime() != null || postUpdateReqDto.assistanceEndTime() != null) {
 
             updateAssistanceTime = new AssistanceTime(
-                    postUpdateReqDto.assistanceStartTime() != null ? postUpdateReqDto.assistanceStartTime() : this.assistanceTime.getAssistanceStartTime(),
+                    postUpdateReqDto.assistanceStartTime() != null ? postUpdateReqDto.assistanceStartTime()
+                            : this.assistanceTime.getAssistanceStartTime(),
                     postUpdateReqDto.assistanceEndTime() != null ? postUpdateReqDto.assistanceEndTime() : this.assistanceTime.getAssistanceEndTime()
             );
         }

--- a/src/main/java/econo/buddybridge/post/event/PostDeleteEvent.java
+++ b/src/main/java/econo/buddybridge/post/event/PostDeleteEvent.java
@@ -1,0 +1,18 @@
+package econo.buddybridge.post.event;
+
+import econo.buddybridge.common.event.DomainEvent;
+import econo.buddybridge.post.entity.Post;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostDeleteEvent extends DomainEvent {
+
+    private final Post post;
+
+    public static PostDeleteEvent from(Post post) {
+        return new PostDeleteEvent(post);
+    }
+}

--- a/src/main/java/econo/buddybridge/post/event/handler/PostDeleteEventHandler.java
+++ b/src/main/java/econo/buddybridge/post/event/handler/PostDeleteEventHandler.java
@@ -1,0 +1,31 @@
+package econo.buddybridge.post.event.handler;
+
+import econo.buddybridge.post.entity.Post;
+import econo.buddybridge.post.event.PostDeleteEvent;
+import econo.buddybridge.post.repository.PostRepository;
+import econo.buddybridge.report.repository.PostReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class PostDeleteEventHandler {
+
+    private final PostReportRepository postReportRepository;
+    private final PostRepository postRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handlePostDeleteEvent(PostDeleteEvent event) {
+        Post post = event.getPost();
+
+        // 신고된 게시글은 soft delete
+        // 신고된 게시글이 아닌 경우 완전 삭제
+        if (postReportRepository.existsByReportedPost(post)) {
+            post.delete();
+        } else {
+            postRepository.delete(post);
+        }
+    }
+}

--- a/src/main/java/econo/buddybridge/post/repository/PostRepository.java
+++ b/src/main/java/econo/buddybridge/post/repository/PostRepository.java
@@ -1,8 +1,13 @@
 package econo.buddybridge.post.repository;
 
 import econo.buddybridge.post.entity.Post;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 
+    @Query("SELECT p FROM Post p JOIN FETCH p.author WHERE p.id = :postId")
+    Optional<Post> findByIdWithAuthor(@Param("postId") Long postId);
 }

--- a/src/main/java/econo/buddybridge/post/repository/PostRepository.java
+++ b/src/main/java/econo/buddybridge/post/repository/PostRepository.java
@@ -10,4 +10,15 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
 
     @Query("SELECT p FROM Post p JOIN FETCH p.author WHERE p.id = :postId")
     Optional<Post> findByIdWithAuthor(@Param("postId") Long postId);
+
+    /**
+     * {@link @Filter} 어노테이션을 사용하기 위해서는 findById 메소드를 오버라이드 해야한다. <br>
+     * 일반 findById 메소드는 EntityMananger.find 메소드를 사용하기 때문에 @Filter 어노테이션 적용이 불가능하다.
+     *
+     * @param postId
+     * @return
+     */
+    @Override
+    @Query("SELECT p FROM Post p WHERE p.id = :postId")
+    Optional<Post> findById(@Param("postId") Long postId);
 }

--- a/src/main/java/econo/buddybridge/post/service/PostService.java
+++ b/src/main/java/econo/buddybridge/post/service/PostService.java
@@ -13,15 +13,16 @@ import econo.buddybridge.post.entity.District;
 import econo.buddybridge.post.entity.Post;
 import econo.buddybridge.post.entity.PostStatus;
 import econo.buddybridge.post.entity.PostType;
+import econo.buddybridge.post.event.PostDeleteEvent;
 import econo.buddybridge.post.exception.PostDeleteNotAllowedException;
 import econo.buddybridge.post.exception.PostNotFoundException;
 import econo.buddybridge.post.exception.PostUpdateNotAllowedException;
 import econo.buddybridge.post.repository.PostRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 
 @Service
@@ -30,6 +31,7 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final MemberService memberService;
+    private final ApplicationEventPublisher publisher;
 
     // 존재하는 포스트인지 확인
     @Transactional(readOnly = true)
@@ -56,7 +58,7 @@ public class PostService {
 
     @Transactional(readOnly = true) // 전체 게시글 조회
     public PostCustomPage getPosts(Long memberId, Integer page, Integer size, String sort, PostType postType, PostStatus postStatus,
-                                   List<DisabilityType> disabilityType, List<AssistanceType> assistanceType) {
+            List<DisabilityType> disabilityType, List<AssistanceType> assistanceType) {
         return postRepository.findPosts(memberId, page - 1, size, sort, postType, postStatus, disabilityType, assistanceType);
     }
 
@@ -85,9 +87,10 @@ public class PostService {
 
     @Transactional // 게시글 수정
     public Long updatePost(Long postId, PostUpdateReqDto postUpdateReqDto, Long memberId) {
-        Post post = findPostByIdOrThrow(postId);
+        Post post = findPostByIdWithAuthorOrThrow(postId);
+        Member author = memberService.findMemberByIdOrThrow(memberId);
 
-        if (!post.getAuthor().getId().equals(memberId)) {
+        if (!post.getAuthor().equals(author)) {
             throw PostUpdateNotAllowedException.EXCEPTION;
         }
 
@@ -98,10 +101,13 @@ public class PostService {
 
     @Transactional // 게시글 삭제
     public void deletePost(Long postId, Long memberId) {
-        Post post = findPostByIdOrThrow(postId);
-        if (!post.getAuthor().getId().equals(memberId)) {
+        Post post = findPostByIdWithAuthorOrThrow(postId);
+        Member author = memberService.findMemberByIdOrThrow(memberId);
+
+        if (!post.getAuthor().equals(author)) {
             throw PostDeleteNotAllowedException.EXCEPTION;
         }
-        postRepository.deleteById(postId);
+
+        publisher.publishEvent(PostDeleteEvent.from(post));
     }
 }

--- a/src/main/java/econo/buddybridge/post/service/PostService.java
+++ b/src/main/java/econo/buddybridge/post/service/PostService.java
@@ -38,6 +38,12 @@ public class PostService {
                 .orElseThrow(() -> PostNotFoundException.EXCEPTION);
     }
 
+    @Transactional(readOnly = true)
+    public Post findPostByIdWithAuthorOrThrow(Long postId) {
+        return postRepository.findByIdWithAuthor(postId)
+                .orElseThrow(() -> PostNotFoundException.EXCEPTION);
+    }
+
     @Transactional(readOnly = true) // 단일 게시글 조회
     public PostDetailDto findPost(Long memberId, Long postId) {
         return postRepository.findByMemberIdAndPostId(memberId, postId);

--- a/src/main/java/econo/buddybridge/report/controller/ReportController.java
+++ b/src/main/java/econo/buddybridge/report/controller/ReportController.java
@@ -1,0 +1,80 @@
+package econo.buddybridge.report.controller;
+
+import econo.buddybridge.auth.resolver.MemberTokenId;
+import econo.buddybridge.common.annotation.AllowAnonymous;
+import econo.buddybridge.report.dto.ReportRequest;
+import econo.buddybridge.report.entity.ReportType;
+import econo.buddybridge.report.service.CommentReportService;
+import econo.buddybridge.report.service.MatchingReportService;
+import econo.buddybridge.report.service.PostReportService;
+import econo.buddybridge.utils.api.ApiResponse;
+import econo.buddybridge.utils.api.ApiResponse.CustomBody;
+import econo.buddybridge.utils.api.ApiResponseGenerator;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/reports")
+@RequiredArgsConstructor
+@Tag(name = "신고 API", description = "신고 관련 API")
+public class ReportController {
+
+    private final PostReportService postReportService;
+    private final CommentReportService commentReportService;
+    private final MatchingReportService matchingReportService;
+
+    @Operation(summary = "신고 유형 조회", description = "신고 유형을 조회합니다.")
+    @GetMapping("/types")
+    @AllowAnonymous
+    public ApiResponse<CustomBody<List<String>>> getReportTypes() {
+        List<String> types = Arrays.stream(ReportType.values())
+                .map(ReportType::getValue)
+                .toList();
+        return ApiResponseGenerator.success(types, HttpStatus.OK);
+    }
+
+    @Operation(summary = "게시글 신고", description = "게시글을 신고합니다.")
+    @PostMapping("/posts/{post-id}")
+    public ApiResponse<CustomBody<Void>> reportPost(
+            @PathVariable("post-id") Long postId,
+            @Valid @RequestBody ReportRequest reportRequest,
+            @Parameter(hidden = true) @MemberTokenId Long memberId
+    ) {
+        postReportService.reportPost(postId, reportRequest, memberId);
+        return ApiResponseGenerator.success(HttpStatus.CREATED);
+    }
+
+    @Operation(summary = "댓글 신고", description = "댓글을 신고합니다.")
+    @PostMapping("/comments/{comment-id}")
+    public ApiResponse<CustomBody<Void>> reportComment(
+            @PathVariable("comment-id") Long commentId,
+            @Valid @RequestBody ReportRequest reportRequest,
+            @Parameter(hidden = true) @MemberTokenId Long memberId
+    ) {
+        commentReportService.reportComment(commentId, reportRequest, memberId);
+        return ApiResponseGenerator.success(HttpStatus.CREATED);
+    }
+
+    @Operation(summary = "매칭 신고", description = "매칭을 신고합니다.")
+    @PostMapping("/matchings/{matching-id}")
+    public ApiResponse<CustomBody<Void>> reportMatching(
+            @PathVariable("matching-id") Long matchingId,
+            @Valid @RequestBody ReportRequest reportRequest,
+            @Parameter(hidden = true) @MemberTokenId Long memberId
+    ) {
+        matchingReportService.reportMatching(matchingId, reportRequest, memberId);
+        return ApiResponseGenerator.success(HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/econo/buddybridge/report/dto/ReportRequest.java
+++ b/src/main/java/econo/buddybridge/report/dto/ReportRequest.java
@@ -1,0 +1,21 @@
+package econo.buddybridge.report.dto;
+
+import econo.buddybridge.common.validation.EnumTypeValue;
+import econo.buddybridge.report.entity.ReportType;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+
+public record ReportRequest(
+        @EnumTypeValue(enumClass = ReportType.class)
+        String reportType,
+
+        @NotNull(message = "신고 사유는 NULL일 수 없습니다.")
+        String reportReason
+) {
+
+    @AssertTrue(message = "기타 신고 사유는 반드시 입력해야 합니다.")
+    private boolean isEtcContentNotEmpty() {
+        return !ReportType.기타.getValue().equals(reportType) ||
+                (reportReason != null && !reportReason.isBlank());
+    }
+}

--- a/src/main/java/econo/buddybridge/report/entity/CommentReport.java
+++ b/src/main/java/econo/buddybridge/report/entity/CommentReport.java
@@ -1,0 +1,47 @@
+package econo.buddybridge.report.entity;
+
+import econo.buddybridge.comment.entity.Comment;
+import econo.buddybridge.member.entity.Member;
+import econo.buddybridge.report.exception.ReportSelfCommentException;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@DiscriminatorValue("COMMENT")
+@Table(name = "COMMENT_REPORT")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentReport extends Report {
+
+    @ManyToOne(fetch = FetchType.LAZY)  // 하나의 댓글은 여러 신고를 받을 수 있음
+    @JoinColumn(name = "reported_comment_id")
+    private Comment reportedComment;
+
+    @Builder
+    private CommentReport(Member reporter, Member reported, ReportType reportType, String reportReason, Comment reportedComment) {
+        super(reporter, reported, reportType, reportReason);
+        this.reportedComment = reportedComment;
+    }
+
+    public static CommentReport of(Comment comment, Member member, String reportType, String reportReason) {
+        if (comment.getAuthor().equals(member)) {
+            throw ReportSelfCommentException.EXCEPTION;
+        }
+
+        return CommentReport.builder()
+                .reporter(member)
+                .reported(comment.getAuthor())
+                .reportType(ReportType.fromValue(reportType))
+                .reportReason(reportReason)
+                .reportedComment(comment)
+                .build();
+    }
+}

--- a/src/main/java/econo/buddybridge/report/entity/MatchingReport.java
+++ b/src/main/java/econo/buddybridge/report/entity/MatchingReport.java
@@ -1,0 +1,50 @@
+package econo.buddybridge.report.entity;
+
+import econo.buddybridge.matching.entity.Matching;
+import econo.buddybridge.member.entity.Member;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@DiscriminatorValue("MATCHING")
+@Table(name = "MATCHING_REPORT")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MatchingReport extends Report {
+
+    @OneToOne(fetch = FetchType.LAZY)   // 매칭은 하나의 신고만 받을 수 있음 (1:1)
+    @JoinColumn(name = "reported_matching_id")
+    private Matching reportedMatching;
+
+    @Builder
+    public MatchingReport(Member reporter, Member reported, ReportType reportType, String reportReason, Matching reportedMatching) {
+        super(reporter, reported, reportType, reportReason);
+        this.reportedMatching = reportedMatching;
+    }
+
+    public static MatchingReport of(Matching matching, Member member, String reportType, String reportReason) {
+        // 매칭 신고는 신고자와 신고 대상이 같을 수 없음
+        Member reported;
+        if (matching.getGiver().equals(member)) {
+            reported = matching.getTaker();
+        } else {
+            reported = matching.getGiver();
+        }
+
+        return MatchingReport.builder()
+                .reporter(member)
+                .reported(reported)
+                .reportType(ReportType.fromValue(reportType))
+                .reportReason(reportReason)
+                .reportedMatching(matching)
+                .build();
+    }
+}

--- a/src/main/java/econo/buddybridge/report/entity/PostReport.java
+++ b/src/main/java/econo/buddybridge/report/entity/PostReport.java
@@ -1,0 +1,47 @@
+package econo.buddybridge.report.entity;
+
+import econo.buddybridge.member.entity.Member;
+import econo.buddybridge.post.entity.Post;
+import econo.buddybridge.report.exception.ReportSelfPostException;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@DiscriminatorValue("POST")
+@Table(name = "POST_REPORT")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostReport extends Report {
+
+    @ManyToOne(fetch = FetchType.LAZY)  // 하나의 게시글은 여러 신고를 받을 수 있음
+    @JoinColumn(name = "reported_post_id")
+    private Post reportedPost;
+
+    @Builder
+    private PostReport(Member reporter, Member reported, ReportType reportType, String reportReason, Post reportedPost) {
+        super(reporter, reported, reportType, reportReason);
+        this.reportedPost = reportedPost;
+    }
+
+    public static PostReport of(Post post, Member member, String reportType, String reportReason) {
+        if (post.getAuthor().equals(member)) {
+            throw ReportSelfPostException.EXCEPTION;
+        }
+
+        return PostReport.builder()
+                .reporter(member)
+                .reported(post.getAuthor())
+                .reportType(ReportType.fromValue(reportType))
+                .reportReason(reportReason)
+                .reportedPost(post)
+                .build();
+    }
+}

--- a/src/main/java/econo/buddybridge/report/entity/Report.java
+++ b/src/main/java/econo/buddybridge/report/entity/Report.java
@@ -1,0 +1,56 @@
+package econo.buddybridge.report.entity;
+
+
+import econo.buddybridge.common.persistence.BaseEntity;
+import econo.buddybridge.member.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "report_target_type")
+@Table(name = "REPORT")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class Report extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id")
+    private Member reporter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reported_id")
+    private Member reported;
+
+    @Enumerated(value = EnumType.STRING)
+    private ReportType reportType;
+
+    private String reportReason;
+
+    protected Report(Member reporter, Member reported, ReportType reportType, String reportReason) {
+        this.reporter = reporter;
+        this.reported = reported;
+        this.reportType = reportType;
+        this.reportReason = reportReason;
+    }
+}

--- a/src/main/java/econo/buddybridge/report/entity/ReportType.java
+++ b/src/main/java/econo/buddybridge/report/entity/ReportType.java
@@ -1,0 +1,32 @@
+package econo.buddybridge.report.entity;
+
+import econo.buddybridge.common.validation.ValueEnum;
+import econo.buddybridge.report.exception.ReportInvalidTypeException;
+import java.util.Arrays;
+
+public enum ReportType implements ValueEnum<String> {
+    욕설_혐오_차별적_표현("욕설/혐오/차별적 표현"),
+    불쾌한_표현("불쾌한 표현"),
+    스팸_홍보_도배글("스팸/홍보/도배글"),
+    불법정보_포함("불법정보 포함"),
+    기타("기타")
+    ;
+
+    private final String value;
+
+    ReportType(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    public static ReportType fromValue(String value) {
+        return Arrays.stream(ReportType.values())
+                .filter(reportType -> reportType.getValue().equals(value))
+                .findFirst()
+                .orElseThrow(() -> ReportInvalidTypeException.EXCEPTION);
+    }
+}

--- a/src/main/java/econo/buddybridge/report/exception/ReportCommentAlreadyExistsException.java
+++ b/src/main/java/econo/buddybridge/report/exception/ReportCommentAlreadyExistsException.java
@@ -1,0 +1,12 @@
+package econo.buddybridge.report.exception;
+
+import econo.buddybridge.common.exception.BusinessException;
+
+public class ReportCommentAlreadyExistsException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new ReportCommentAlreadyExistsException();
+
+    private ReportCommentAlreadyExistsException() {
+        super(ReportErrorCode.REPORT_COMMENT_ALREADY_EXISTS);
+    }
+}

--- a/src/main/java/econo/buddybridge/report/exception/ReportErrorCode.java
+++ b/src/main/java/econo/buddybridge/report/exception/ReportErrorCode.java
@@ -1,0 +1,40 @@
+package econo.buddybridge.report.exception;
+
+import econo.buddybridge.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum ReportErrorCode implements ErrorCode {
+    REPORT_NOT_FOUND("R001", HttpStatus.NOT_FOUND, "신고를 찾을 수 없습니다."),
+    REPORT_POST_ALREADY_EXISTS("R002", HttpStatus.BAD_REQUEST, "이미 신고한 게시글입니다."),
+    REPORT_COMMENT_ALREADY_EXISTS("R003", HttpStatus.BAD_REQUEST, "이미 신고한 댓글입니다."),
+    REPORT_MATCHING_ALREADY_EXISTS("R004", HttpStatus.BAD_REQUEST, "이미 신고한 매칭입니다."),
+    REPORT_INVALID_TYPE("R005", HttpStatus.BAD_REQUEST, "유효하지 않은 신고 유형입니다."),
+    REPORT_SELF_POST("R006", HttpStatus.BAD_REQUEST, "자신의 게시글을 신고할 수 없습니다."),
+    REPORT_SELF_COMMENT("R007", HttpStatus.BAD_REQUEST, "자신의 댓글을 신고할 수 없습니다."),
+    ;
+
+    private final String code;
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    ReportErrorCode(String code, HttpStatus httpStatus, String message) {
+        this.code = code;
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/econo/buddybridge/report/exception/ReportInvalidTypeException.java
+++ b/src/main/java/econo/buddybridge/report/exception/ReportInvalidTypeException.java
@@ -1,0 +1,12 @@
+package econo.buddybridge.report.exception;
+
+import econo.buddybridge.common.exception.BusinessException;
+
+public class ReportInvalidTypeException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new ReportInvalidTypeException();
+
+    private ReportInvalidTypeException() {
+        super(ReportErrorCode.REPORT_INVALID_TYPE);
+    }
+}

--- a/src/main/java/econo/buddybridge/report/exception/ReportMatchingAlreadyExistsException.java
+++ b/src/main/java/econo/buddybridge/report/exception/ReportMatchingAlreadyExistsException.java
@@ -1,0 +1,12 @@
+package econo.buddybridge.report.exception;
+
+import econo.buddybridge.common.exception.BusinessException;
+
+public class ReportMatchingAlreadyExistsException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new ReportMatchingAlreadyExistsException();
+
+    private ReportMatchingAlreadyExistsException() {
+        super(ReportErrorCode.REPORT_MATCHING_ALREADY_EXISTS);
+    }
+}

--- a/src/main/java/econo/buddybridge/report/exception/ReportPostAlreadyExistsException.java
+++ b/src/main/java/econo/buddybridge/report/exception/ReportPostAlreadyExistsException.java
@@ -1,0 +1,12 @@
+package econo.buddybridge.report.exception;
+
+import econo.buddybridge.common.exception.BusinessException;
+
+public class ReportPostAlreadyExistsException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new ReportPostAlreadyExistsException();
+
+    private ReportPostAlreadyExistsException() {
+        super(ReportErrorCode.REPORT_POST_ALREADY_EXISTS);
+    }
+}

--- a/src/main/java/econo/buddybridge/report/exception/ReportSelfCommentException.java
+++ b/src/main/java/econo/buddybridge/report/exception/ReportSelfCommentException.java
@@ -1,0 +1,12 @@
+package econo.buddybridge.report.exception;
+
+import econo.buddybridge.common.exception.BusinessException;
+
+public class ReportSelfCommentException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new ReportSelfCommentException();
+
+    private ReportSelfCommentException() {
+        super(ReportErrorCode.REPORT_SELF_COMMENT);
+    }
+}

--- a/src/main/java/econo/buddybridge/report/exception/ReportSelfPostException.java
+++ b/src/main/java/econo/buddybridge/report/exception/ReportSelfPostException.java
@@ -1,0 +1,12 @@
+package econo.buddybridge.report.exception;
+
+import econo.buddybridge.common.exception.BusinessException;
+
+public class ReportSelfPostException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new ReportSelfPostException();
+
+    private ReportSelfPostException() {
+        super(ReportErrorCode.REPORT_SELF_POST);
+    }
+}

--- a/src/main/java/econo/buddybridge/report/repository/CommentReportRepository.java
+++ b/src/main/java/econo/buddybridge/report/repository/CommentReportRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface CommentReportRepository extends JpaRepository<CommentReport, Long> {
 
     boolean existsByReportedCommentAndReporter(Comment comment, Member member);
+
+    boolean existsByReportedComment(Comment reportedComment);
 }

--- a/src/main/java/econo/buddybridge/report/repository/CommentReportRepository.java
+++ b/src/main/java/econo/buddybridge/report/repository/CommentReportRepository.java
@@ -1,0 +1,11 @@
+package econo.buddybridge.report.repository;
+
+import econo.buddybridge.comment.entity.Comment;
+import econo.buddybridge.member.entity.Member;
+import econo.buddybridge.report.entity.CommentReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentReportRepository extends JpaRepository<CommentReport, Long> {
+
+    boolean existsByReportedCommentAndReporter(Comment comment, Member member);
+}

--- a/src/main/java/econo/buddybridge/report/repository/MatchingReportRepository.java
+++ b/src/main/java/econo/buddybridge/report/repository/MatchingReportRepository.java
@@ -1,0 +1,11 @@
+package econo.buddybridge.report.repository;
+
+import econo.buddybridge.matching.entity.Matching;
+import econo.buddybridge.member.entity.Member;
+import econo.buddybridge.report.entity.MatchingReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MatchingReportRepository extends JpaRepository<MatchingReport, Long> {
+
+    boolean existsByReportedMatchingAndReporter(Matching matching, Member member);
+}

--- a/src/main/java/econo/buddybridge/report/repository/MatchingReportRepository.java
+++ b/src/main/java/econo/buddybridge/report/repository/MatchingReportRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MatchingReportRepository extends JpaRepository<MatchingReport, Long> {
 
     boolean existsByReportedMatchingAndReporter(Matching matching, Member member);
+
+    boolean existsByReportedMatching(Matching reportedMatching);
 }

--- a/src/main/java/econo/buddybridge/report/repository/PostReportRepository.java
+++ b/src/main/java/econo/buddybridge/report/repository/PostReportRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface PostReportRepository extends JpaRepository<PostReport, Long> {
 
     boolean existsByReportedPostAndReporter(Post reportedPost, Member reporter);
+
+    boolean existsByReportedPost(Post reportedPost);
 }

--- a/src/main/java/econo/buddybridge/report/repository/PostReportRepository.java
+++ b/src/main/java/econo/buddybridge/report/repository/PostReportRepository.java
@@ -1,0 +1,11 @@
+package econo.buddybridge.report.repository;
+
+import econo.buddybridge.member.entity.Member;
+import econo.buddybridge.post.entity.Post;
+import econo.buddybridge.report.entity.PostReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostReportRepository extends JpaRepository<PostReport, Long> {
+
+    boolean existsByReportedPostAndReporter(Post reportedPost, Member reporter);
+}

--- a/src/main/java/econo/buddybridge/report/service/CommentReportService.java
+++ b/src/main/java/econo/buddybridge/report/service/CommentReportService.java
@@ -1,0 +1,39 @@
+package econo.buddybridge.report.service;
+
+import econo.buddybridge.comment.entity.Comment;
+import econo.buddybridge.comment.service.CommentService;
+import econo.buddybridge.member.entity.Member;
+import econo.buddybridge.member.service.MemberService;
+import econo.buddybridge.report.dto.ReportRequest;
+import econo.buddybridge.report.entity.CommentReport;
+import econo.buddybridge.report.exception.ReportCommentAlreadyExistsException;
+import econo.buddybridge.report.repository.CommentReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentReportService {
+
+    private final CommentReportRepository commentReportRepository;
+    private final CommentService commentService;
+    private final MemberService memberService;
+
+    @Transactional
+    public void reportComment(Long commentId, ReportRequest reportRequest, Long memberId) {
+        Comment comment = commentService.findCommentByIdWithAuthorOrThrow(commentId);
+        Member member = memberService.findMemberByIdOrThrow(memberId);
+
+        if (commentReportRepository.existsByReportedCommentAndReporter(comment, member)) {
+            throw ReportCommentAlreadyExistsException.EXCEPTION;
+        }
+
+        commentReportRepository.save(CommentReport.of(
+                comment,
+                member,
+                reportRequest.reportType(),
+                reportRequest.reportReason()
+        ));
+    }
+}

--- a/src/main/java/econo/buddybridge/report/service/MatchingReportService.java
+++ b/src/main/java/econo/buddybridge/report/service/MatchingReportService.java
@@ -1,0 +1,39 @@
+package econo.buddybridge.report.service;
+
+import econo.buddybridge.matching.entity.Matching;
+import econo.buddybridge.matching.service.MatchingService;
+import econo.buddybridge.member.entity.Member;
+import econo.buddybridge.member.service.MemberService;
+import econo.buddybridge.report.dto.ReportRequest;
+import econo.buddybridge.report.entity.MatchingReport;
+import econo.buddybridge.report.exception.ReportMatchingAlreadyExistsException;
+import econo.buddybridge.report.repository.MatchingReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MatchingReportService {
+
+    private final MatchingReportRepository matchingReportRepository;
+    private final MatchingService matchingService;
+    private final MemberService memberService;
+
+    @Transactional
+    public void reportMatching(Long matchingId, ReportRequest reportRequest, Long memberId) {
+        Matching matching = matchingService.findMatchingByIdWithMembers(matchingId);
+        Member member = memberService.findMemberByIdOrThrow(memberId);
+
+        if (matchingReportRepository.existsByReportedMatchingAndReporter(matching, member)) {
+            throw ReportMatchingAlreadyExistsException.EXCEPTION;
+        }
+
+        matchingReportRepository.save(MatchingReport.of(
+                matching,
+                member,
+                reportRequest.reportType(),
+                reportRequest.reportReason()
+        ));
+    }
+}

--- a/src/main/java/econo/buddybridge/report/service/PostReportService.java
+++ b/src/main/java/econo/buddybridge/report/service/PostReportService.java
@@ -1,0 +1,39 @@
+package econo.buddybridge.report.service;
+
+import econo.buddybridge.member.entity.Member;
+import econo.buddybridge.member.service.MemberService;
+import econo.buddybridge.post.entity.Post;
+import econo.buddybridge.post.service.PostService;
+import econo.buddybridge.report.dto.ReportRequest;
+import econo.buddybridge.report.entity.PostReport;
+import econo.buddybridge.report.exception.ReportPostAlreadyExistsException;
+import econo.buddybridge.report.repository.PostReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostReportService {
+
+    private final PostReportRepository postReportRepository;
+    private final PostService postService;
+    private final MemberService memberService;
+
+    @Transactional
+    public void reportPost(Long postId, ReportRequest reportRequest, Long memberId) {
+        Post post = postService.findPostByIdWithAuthorOrThrow(postId);
+        Member member = memberService.findMemberByIdOrThrow(memberId);
+
+        if (postReportRepository.existsByReportedPostAndReporter(post, member)) {
+            throw ReportPostAlreadyExistsException.EXCEPTION;
+        }
+
+        postReportRepository.save(PostReport.of(
+                post,
+                member,
+                reportRequest.reportType(),
+                reportRequest.reportReason()
+        ));
+    }
+}


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

게시글, 댓글, 매칭(채팅방)에 대한 신고하기 API 구현

## 참고 사항

- <ins>**신고 내역에 있으면 soft delete, 없으면 hard delete**</ins>라는 규칙에서 각 엔티티들의 삭제 작업(`delete~`)들이 이러한 규칙을 알아야 할까? 그냥 삭제 처리만 하고 나머지는 알아서 해주면 안될까? 하는 고민이 되었습니다.

  - 그래서 삭제 작업의 경우 이벤트(`~DeleteEvent`)를 발행하고 이벤트 핸들러에서 해당 작업을 처리하도록 구현했습니다.

- Soft Delete 적용은 hibernate의 `@Filter`를 이용하고 필터 설정, 해제를 위해 `AOP`를 사용했습니다.

  - 이 필터는 활성화 시 조회 작업에서 `deleted = false` 조건을 추가해 soft delete된 내용들은 조회되지 않도록 합니다.
  - 해당 필터를 hibernate의 `session`에 적용하고 해제하는 작업은 `SessionFilterManager`을 이용합니다.

- `findbyId` 쿼리들의 경우 `EntityMananger.find` 메소드를 사용하기 때문에 `@Filter` 어노테이션 적용이 불가능해 `JPQL`을 사용하도록 재정의했습니다. [관련 레퍼런스](https://stackoverflow.com/questions/65980495/hibernate-filter-does-not-work-with-spring-jparepository-findbyid-method) 참고해주세요

- 이벤트와 핸들러는 제네릭으로 만들어 함수를 간소화 하는 작업도 추후 진행할 예정입니다.

## 관련 이슈

close #225 

## 체크리스트

- [x] 코드가 제대로 작동하는지 확인
- [x] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [x] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
