### PR TITLE
[CHORE] Log Rotation 적용

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,7 +59,14 @@ logging:
     econo.buddybridge.auth.client.kakao: debug
 
   file: # 로그 파일 설정
-    name: /app/application.log
+    name: /app/log/application.log # name 또는 path 설정 필수
+
+  logback:
+    rollingpolicy:
+      max-history: 30 # default: 7
+      max-file-size: 10MB # default: 10MB
+      file-name-pattern: /app/log/application-%d{yyyy-MM-dd}-%i.gz # 압축해서 보관 -> 디스크 절약
+      total-size-cap: 5GB # default: 제한 없음
 
 # Register P6LogFactory to log JDBC events
 decorator:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,7 +56,7 @@ logging:
 
     p6spy: info
 
-    study.learnsocket.auth.kakao: debug # FeignClient 로그 레벨 설정
+    econo.buddybridge.auth.client.kakao: debug
 
   file: # 로그 파일 설정
     name: /app/application.log
@@ -95,6 +95,14 @@ spring:
     init:
       mode: never
 
+logging:
+  level:
+    org.springframework:
+      transaction.interceptor: trace    # 트랜잭션 로그 설정
+
+    p6spy: warn
+
+    econo.buddybridge.auth.client.kakao: error
 ---
 spring:
   config:
@@ -108,3 +116,12 @@ spring:
   sql:
     init:
       mode: never
+
+logging:
+  level:
+    org.springframework:
+      transaction.interceptor:     # 트랜잭션 로그 설정
+
+    p6spy: warn
+
+    econo.buddybridge.auth.client.kakao: error


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [X] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

스프링 Log 구현체 `Logback` 설정을 통한 log rotation 적용
Develop 환경에서 Log Level 설정

## 참고 사항

Spring의 경우 `spring-boot-starter-web`에 `logging` 의존성을 포함하고 있으며, 기본적으로 `Logback` 구현체를 사용하고 있습니다.

```application.yml
logging:
  level:
    ...

  file: # 로그 파일 설정
    name: /app/log/application.log # name 또는 path 설정 필수

  logback:
    rollingpolicy:
      max-history: 30 # default: 7
      max-file-size: 10MB # default: 10MB
      file-name-pattern: /app/log/application-%d{yyyy-MM-dd}-%i.gz # 압축해서 보관 -> 디스크 절약
      total-size-cap: 5GB # default: 제한 없음
```
application.yml 파일의 경우 위와 같이 logging 설정이 가능한데
file:name: 혹은 file:path: 가 없을 경우 로그 파일이 생성되지 않습니다.

이전에는 /app/application.log로 만들었지만 log 디렉터리를 하나 추가했습니다.
/app/log/application.log 다시 한번 확인해주세요!

- max-history: 최대 몇 일간의 로그를 보관할지
- max-file-size: 각 파일 당 용량을 얼마나 할당할 지
- file-name-pattern: 이후 생성되는 로그 파일들의 이름 규칙
- total-size-cap: 로그가 해당 용량을 넘어서면 가장 오래된 로그 파일부터 삭제하여 최대 용량 유지

---

application.yml 설정이 적용될 경우
`docker-compose.yml` 파일에서 volumes 부분을 수정해줘야합니다.
파일 마운트에서 디렉터리 마운트로 변경했습니다.

```docker-compose.yml
  backend:
    image: audejr123/buddies-docker-repo:latest
    env_file:
      - .env
    ports:
      - "8080:8080"
    volumes:
      - ~/buddies/log:/app/log

    depends_on:
      - mariadb
      - redis

    restart: always
```
---
번외

EC2의 /var/lib/docker/container 경로에 쌓이는 로그들은 Docker의 기본 Logging 시스템이 생성한 Log들로 표준 출력과 에러를 자동으로 캡처해 해당 디렉터리에 저장합니다.
```
ubuntu@buddies-webserver:/var/lib/docker$ ls
buildkit  containers  engine-id  image  network  overlay2  plugins  runtimes  swarm  tmp  volumes
ubuntu@buddies-webserver:/var/lib/docker/containers$ ls
0e27028dc99d2b5ecc4642107312769f923609c85213e10e9bdf78b9fcff5ba9  90cf3d5b61254765af49e3b4694f35f080757037374ab1120b95877a0bfe595c
804df6139241e59ddadb2c4d47955dc7b2653ce340a38f46c802c0b4bad02759
```

해당 Log에도 rotation을 설정할 수 있으며, 다음과 같이 docker-compose.yml에서 설정 가능합니다.
기본적으로 json 파일 형식으로 저장하며 max-size는 최대 크기, max-file은 최대 갯수, compress는 압축 여부를 나타냅니다.
```docker-compose.yml
backend:
  ...
  logging:
    driver: "json-file"
    options:
      max-size: "10m"
      max-file: "10"
      compress: "true" # 로그 파일 압축
```

윈도우에서는 해당 위치로 접근 하는 방법을 찾다가 막혀서 docker-compose.yml에서 위 설정을 해줬을 때 제대로 작동하는지 테스트 하진 못했습니다.

## 관련 이슈

close #226 

## 체크리스트

- [X] 코드가 제대로 작동하는지 확인
- [X] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [ ] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
