### PR TITLE
[FEAT] 채팅방 안읽은 메시지 개수 반환

### DIFF
--- a/src/main/java/econo/buddybridge/chat/chatmessage/controller/ChatMessageController.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/controller/ChatMessageController.java
@@ -3,8 +3,8 @@ package econo.buddybridge.chat.chatmessage.controller;
 import econo.buddybridge.chat.chatmessage.dto.ChatMessageReqDto;
 import econo.buddybridge.chat.chatmessage.dto.ChatMessageResDto;
 import econo.buddybridge.chat.chatmessage.service.ChatMessageService;
-import econo.buddybridge.chat.chatmessage.service.MessageReadStatusService;
 import econo.buddybridge.websocket.WebSocketPrincipal;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -12,14 +12,11 @@ import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.security.Principal;
-
 @RestController
 @RequiredArgsConstructor
 public class ChatMessageController {
 
     private final ChatMessageService chatMessageService;
-    private final MessageReadStatusService messageReadStatusService;
 
     @MessageMapping("/chat/{matching-id}") // 메시지 보내기 // /api/app/chat/{room-id} - pub
     @SendTo("/api/queue/chat/{matching-id}") // 구독 경로 - sub
@@ -30,9 +27,6 @@ public class ChatMessageController {
     ) {
         WebSocketPrincipal webSocketPrincipal = (WebSocketPrincipal) principal;
         Long senderId = webSocketPrincipal.getSenderId();
-
-        messageReadStatusService.updateLastReadTime(matchingId, senderId);
-
         return chatMessageService.save(senderId, chatMessageReqDto, matchingId);
     }
 }

--- a/src/main/java/econo/buddybridge/chat/chatmessage/controller/ChatMessageController.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/controller/ChatMessageController.java
@@ -3,6 +3,7 @@ package econo.buddybridge.chat.chatmessage.controller;
 import econo.buddybridge.chat.chatmessage.dto.ChatMessageReqDto;
 import econo.buddybridge.chat.chatmessage.dto.ChatMessageResDto;
 import econo.buddybridge.chat.chatmessage.service.ChatMessageService;
+import econo.buddybridge.chat.chatmessage.service.MessageReadStatusService;
 import econo.buddybridge.websocket.WebSocketPrincipal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
@@ -18,6 +19,7 @@ import java.security.Principal;
 public class ChatMessageController {
 
     private final ChatMessageService chatMessageService;
+    private final MessageReadStatusService messageReadStatusService;
 
     @MessageMapping("/chat/{matching-id}") // 메시지 보내기 // /api/app/chat/{room-id} - pub
     @SendTo("/api/queue/chat/{matching-id}") // 구독 경로 - sub
@@ -27,6 +29,10 @@ public class ChatMessageController {
             Principal principal
     ) {
         WebSocketPrincipal webSocketPrincipal = (WebSocketPrincipal) principal;
-        return chatMessageService.save(webSocketPrincipal.getSenderId(), chatMessageReqDto, matchingId);
+        Long senderId = webSocketPrincipal.getSenderId();
+
+        messageReadStatusService.updateLastReadTime(matchingId, senderId);
+
+        return chatMessageService.save(senderId, chatMessageReqDto, matchingId);
     }
 }

--- a/src/main/java/econo/buddybridge/chat/chatmessage/dto/ChatMessageCustomPage.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/dto/ChatMessageCustomPage.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 public record ChatMessageCustomPage(
         PostType postType,
         Long postId,
+        Long postAuthorId,
         ReceiverDto receiver,
         List<ChatMessageResDto> chatMessages,
         Long cursor,

--- a/src/main/java/econo/buddybridge/chat/chatmessage/dto/ChatMessageCustomPage.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/dto/ChatMessageCustomPage.java
@@ -1,6 +1,7 @@
 package econo.buddybridge.chat.chatmessage.dto;
 
 import econo.buddybridge.matching.dto.ReceiverDto;
+import econo.buddybridge.post.entity.Post;
 import econo.buddybridge.post.entity.PostType;
 import java.util.List;
 import lombok.Builder;
@@ -16,4 +17,15 @@ public record ChatMessageCustomPage(
         Boolean nextPage
 ) {
 
+    public static ChatMessageCustomPage of(Post post, ReceiverDto receiver, List<ChatMessageResDto> chatMessages, Long cursor, Boolean nextPage) {
+        return ChatMessageCustomPage.builder()
+                .postType(post.getPostType())
+                .postId(post.getId())
+                .postAuthorId(post.getAuthor().getId())
+                .receiver(receiver)
+                .chatMessages(chatMessages)
+                .cursor(cursor)
+                .nextPage(nextPage)
+                .build();
+    }
 }

--- a/src/main/java/econo/buddybridge/chat/chatmessage/dto/ChatMessageResDto.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/dto/ChatMessageResDto.java
@@ -17,4 +17,14 @@ public record ChatMessageResDto(
     @QueryProjection
     public ChatMessageResDto {
     }
+
+    public static ChatMessageResDto of(Long messageId, Long senderId, String content, MessageType messageType, LocalDateTime createdAt) {
+        return ChatMessageResDto.builder()
+                .messageId(messageId)
+                .senderId(senderId)
+                .content(content)
+                .messageType(messageType)
+                .createdAt(createdAt)
+                .build();
+    }
 }

--- a/src/main/java/econo/buddybridge/chat/chatmessage/entity/ChatMessage.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/entity/ChatMessage.java
@@ -3,7 +3,16 @@ package econo.buddybridge.chat.chatmessage.entity;
 import econo.buddybridge.common.persistence.BaseEntity;
 import econo.buddybridge.matching.entity.Matching;
 import econo.buddybridge.member.entity.Member;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +23,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "CHAT_MESSAGE")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatMessage extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -38,14 +48,4 @@ public class ChatMessage extends BaseEntity {
         this.content = content;
         this.messageType = messageType;
     }
-
-    public void updateChatMessage(String content, MessageType messageType) {
-        this.content = content;
-        this.messageType = messageType;
-    }
-
-    public void deleteChatMessage(ChatMessage chatMessage){
-        chatMessage.messageType = MessageType.DELETE;
-    }
-
 }

--- a/src/main/java/econo/buddybridge/chat/chatmessage/entity/ChatMessage.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/entity/ChatMessage.java
@@ -14,6 +14,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,6 +23,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(name = "CHAT_MESSAGE")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ChatMessage extends BaseEntity {
 
     @Id
@@ -41,11 +44,12 @@ public class ChatMessage extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private MessageType messageType;
 
-    @Builder
-    public ChatMessage(Matching matching, Member sender, String content, MessageType messageType) {
-        this.matching = matching;
-        this.sender = sender;
-        this.content = content;
-        this.messageType = messageType;
+    public static ChatMessage of(Matching matching, Member sender, String content, MessageType messageType) {
+        return ChatMessage.builder()
+                .matching(matching)
+                .sender(sender)
+                .content(content)
+                .messageType(messageType)
+                .build();
     }
 }

--- a/src/main/java/econo/buddybridge/chat/chatmessage/entity/MessageReadStatus.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/entity/MessageReadStatus.java
@@ -1,0 +1,52 @@
+package econo.buddybridge.chat.chatmessage.entity;
+
+import econo.buddybridge.common.persistence.BaseEntity;
+import econo.buddybridge.matching.entity.Matching;
+import econo.buddybridge.member.entity.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "MESSAGE_READ_STATUS")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MessageReadStatus extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "matching_id")
+    private Matching matching;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member reader;
+
+    private LocalDateTime lastReadTime;
+
+    public void updateLastReadTime() {
+        this.lastReadTime = LocalDateTime.now();
+    }
+
+    private MessageReadStatus(Matching matching, Member reader, LocalDateTime lastReadTime) {
+        this.matching = matching;
+        this.reader = reader;
+        this.lastReadTime = lastReadTime;
+    }
+
+    public static MessageReadStatus of(Matching matching, Member reader, LocalDateTime lastReadTime) {
+        return new MessageReadStatus(matching, reader, lastReadTime);
+    }
+}

--- a/src/main/java/econo/buddybridge/chat/chatmessage/repository/ChatMessageRepository.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/repository/ChatMessageRepository.java
@@ -1,13 +1,8 @@
 package econo.buddybridge.chat.chatmessage.repository;
 
 import econo.buddybridge.chat.chatmessage.entity.ChatMessage;
-import java.util.List;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>, ChatMessageRepositoryCustom {
 
-    @Query("SELECT cm FROM ChatMessage cm WHERE cm.matching.id = :matchingId ORDER BY cm.id DESC")
-    List<ChatMessage> findLastMessageByMatchingId(Long matchingId, Pageable pageable);
 }

--- a/src/main/java/econo/buddybridge/chat/chatmessage/repository/MessageReadStatusRepository.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/repository/MessageReadStatusRepository.java
@@ -1,0 +1,12 @@
+package econo.buddybridge.chat.chatmessage.repository;
+
+import econo.buddybridge.chat.chatmessage.entity.MessageReadStatus;
+import econo.buddybridge.matching.entity.Matching;
+import econo.buddybridge.member.entity.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageReadStatusRepository extends JpaRepository<MessageReadStatus, Long> {
+
+    Optional<MessageReadStatus> findByMatchingAndReader(Matching matching, Member reader);
+}

--- a/src/main/java/econo/buddybridge/chat/chatmessage/service/ChatMessageService.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/service/ChatMessageService.java
@@ -14,7 +14,10 @@ import econo.buddybridge.member.entity.Member;
 import econo.buddybridge.member.service.MemberService;
 import econo.buddybridge.notification.entity.NotificationType;
 import econo.buddybridge.notification.service.EmitterService;
+import econo.buddybridge.websocket.WebSocketPrincipal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.user.SimpUser;
+import org.springframework.messaging.simp.user.SimpUserRegistry;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,10 +25,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ChatMessageService {
 
+    private static final String SUBSCRIBE_DESTINATION = "/api/queue/chat/";
+
     private final MemberService memberService;
     private final ChatMessageRepository chatMessageRepository;
     private final EmitterService emitterService;
     private final MatchingService matchingService;
+    private final SimpUserRegistry simpUserRegistry;
+    private final MessageReadStatusService messageReadStatusService;
 
     @Transactional // 메시지 저장
     public ChatMessageResDto save(Long senderId, ChatMessageReqDto chatMessageReqDto, Long matchingId) {
@@ -36,10 +43,10 @@ public class ChatMessageService {
         Member receiver = memberService.findMemberByIdOrThrow(receiverId);
 
         ChatMessage chatMessage = ChatMessage.of(matching, sender, chatMessageReqDto.content(), chatMessageReqDto.messageType());
+        chatMessageRepository.save(chatMessage);
 
         sendNotification(receiver, sender, chatMessage, matching);
-
-        chatMessageRepository.save(chatMessage);
+        updateParticipantsReadStatus(matchingId);   // 읽은 시간 갱신
 
         return ChatMessageResDto.of(
                 chatMessage.getId(),
@@ -48,6 +55,17 @@ public class ChatMessageService {
                 chatMessageReqDto.messageType(),
                 chatMessage.getCreatedAt()
         );
+    }
+
+    // 현재 채팅방(매칭)에 참여중인 사용자들의 읽은 시간을 갱신
+    private void updateParticipantsReadStatus(Long matchingId) {
+        String destination = SUBSCRIBE_DESTINATION + matchingId;
+        simpUserRegistry.findSubscriptions(sub -> sub.getDestination().equals(destination))
+                .forEach(sub -> {
+                    SimpUser user = sub.getSession().getUser();
+                    WebSocketPrincipal principal = (WebSocketPrincipal) user.getPrincipal();
+                    messageReadStatusService.updateLastReadTime(matchingId, principal.getSenderId());
+                });
     }
 
     private void sendNotification(Member receiver, Member sender, ChatMessage chatMessage, Matching matching) {

--- a/src/main/java/econo/buddybridge/chat/chatmessage/service/ChatMessageService.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/service/ChatMessageService.java
@@ -30,35 +30,33 @@ public class ChatMessageService {
     @Transactional // 메시지 저장
     public ChatMessageResDto save(Long senderId, ChatMessageReqDto chatMessageReqDto, Long matchingId) {
         Member sender = memberService.findMemberByIdOrThrow(senderId);
-
         Matching matching = matchingService.findMatchingByIdOrThrow(matchingId);
-
-        ChatMessage chatMessage = ChatMessage.builder()
-                .matching(matching)
-                .sender(sender)
-                .content(chatMessageReqDto.content())
-                .messageType(chatMessageReqDto.messageType())
-                .build();
 
         Long receiverId = getReceiverId(sender.getId(), matching.getId());
         Member receiver = memberService.findMemberByIdOrThrow(receiverId);
 
+        ChatMessage chatMessage = ChatMessage.of(matching, sender, chatMessageReqDto.content(), chatMessageReqDto.messageType());
+
+        sendNotification(receiver, sender, chatMessage, matching);
+
+        chatMessageRepository.save(chatMessage);
+
+        return ChatMessageResDto.of(
+                chatMessage.getId(),
+                chatMessage.getSender().getId(),
+                chatMessageReqDto.content(),
+                chatMessageReqDto.messageType(),
+                chatMessage.getCreatedAt()
+        );
+    }
+
+    private void sendNotification(Member receiver, Member sender, ChatMessage chatMessage, Matching matching) {
         emitterService.send(    // 채팅을 받는 사용자에게 알림 전송
                 receiver,
                 String.format(CHAT_NOTIFICATION_MESSAGE, sender.getName(), chatMessage.getContent()),
                 String.format(CHAT_NOTIFICATION_URL, matching.getId()),
                 NotificationType.CHAT
         );
-
-        chatMessageRepository.save(chatMessage);
-
-        return ChatMessageResDto.builder()
-                .messageId(chatMessage.getId())
-                .senderId(chatMessage.getSender().getId())
-                .content(chatMessageReqDto.content())
-                .messageType(chatMessageReqDto.messageType())
-                .createdAt(chatMessage.getCreatedAt())
-                .build();
     }
 
     private Long getReceiverId(Long senderId, Long matchingId) {

--- a/src/main/java/econo/buddybridge/chat/chatmessage/service/MessageReadStatusService.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/service/MessageReadStatusService.java
@@ -1,0 +1,31 @@
+package econo.buddybridge.chat.chatmessage.service;
+
+import econo.buddybridge.chat.chatmessage.entity.MessageReadStatus;
+import econo.buddybridge.chat.chatmessage.repository.MessageReadStatusRepository;
+import econo.buddybridge.matching.entity.Matching;
+import econo.buddybridge.matching.service.MatchingService;
+import econo.buddybridge.member.entity.Member;
+import econo.buddybridge.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MessageReadStatusService {
+
+    private final MatchingService matchingService;
+    private final MemberService memberService;
+    private final MessageReadStatusRepository messageReadStatusRepository;
+
+    @Transactional
+    public void updateLastReadTime(Long matchingId, Long memberId) {
+        Matching matching = matchingService.findMatchingByIdWithMembers(matchingId);
+        Member member = memberService.findMemberByIdOrThrow(memberId);
+
+        matching.validateParticipants(member);
+
+        messageReadStatusRepository.findByMatchingAndReader(matching, member)
+                .ifPresent(MessageReadStatus::updateLastReadTime);
+    }
+}

--- a/src/main/java/econo/buddybridge/common/persistence/filter/aspect/WithDeletedContentAspect.java
+++ b/src/main/java/econo/buddybridge/common/persistence/filter/aspect/WithDeletedContentAspect.java
@@ -25,6 +25,7 @@ public class WithDeletedContentAspect {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         Method method = signature.getMethod();
 
+        // @WithDeletedContent 어노테이션이 붙어있는 경우 필터를 적용하지 않음 (삭제된 데이터도 조회)
         if (method.isAnnotationPresent(WithDeletedContent.class)) {
             return joinPoint.proceed();
         }
@@ -34,6 +35,7 @@ public class WithDeletedContentAspect {
             return joinPoint.proceed();
         }
 
+        // 필터를 활성화하고 비활성화하는 부분을 try-finally로 감싸서 예외 발생 시에도 필터를 비활성화할 수 있도록 함
         try {
             sessionFilterManager.enableFilter(DELETED_FILTER, DELETED_PARAM, false);
             return joinPoint.proceed();

--- a/src/main/java/econo/buddybridge/config/StompChannelInterceptor.java
+++ b/src/main/java/econo/buddybridge/config/StompChannelInterceptor.java
@@ -4,6 +4,7 @@ package econo.buddybridge.config;
 import econo.buddybridge.auth.jwt.service.JwtTokenProvider;
 import econo.buddybridge.websocket.WebSocketPrincipal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
@@ -17,8 +18,6 @@ import org.springframework.stereotype.Component;
 public class StompChannelInterceptor implements ChannelInterceptor {
 
     private final JwtTokenProvider jwtTokenProvider;
-
-    private final static String AUTHORIZATION = "Authorization";
 
     @Override // 커스텀 헤더의 JWT를 가져옴
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -42,14 +41,13 @@ public class StompChannelInterceptor implements ChannelInterceptor {
     }
 
     private Long validateAndGetMemberId(StompHeaderAccessor accessor) {
-        String token = jwtTokenProvider.extractToken(accessor.getFirstNativeHeader(AUTHORIZATION));
+        String token = jwtTokenProvider.extractToken(accessor.getFirstNativeHeader(HttpHeaders.AUTHORIZATION));
         Long memberId = jwtTokenProvider.getMemberIdFromAccessToken(token);
         jwtTokenProvider.existsByMemberIdOrThrow(memberId); // 요청이 들어온 AccessToken에 대한 RefreshToken이 존재하는지 확인
         return memberId;
     }
 
     private void setPrincipal(StompHeaderAccessor accessor, Long memberId) {
-
         if (accessor.getUser() == null) {
             accessor.setUser(WebSocketPrincipal.of(memberId));
         }

--- a/src/main/java/econo/buddybridge/config/StompEventListener.java
+++ b/src/main/java/econo/buddybridge/config/StompEventListener.java
@@ -3,7 +3,6 @@ package econo.buddybridge.config;
 import econo.buddybridge.chat.chatmessage.service.MessageReadStatusService;
 import econo.buddybridge.websocket.WebSocketPrincipal;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
@@ -11,7 +10,6 @@ import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 
 @Component
-@Slf4j
 @RequiredArgsConstructor
 public class StompEventListener {
 

--- a/src/main/java/econo/buddybridge/config/StompEventListener.java
+++ b/src/main/java/econo/buddybridge/config/StompEventListener.java
@@ -1,0 +1,51 @@
+package econo.buddybridge.config;
+
+import econo.buddybridge.chat.chatmessage.service.MessageReadStatusService;
+import econo.buddybridge.websocket.WebSocketPrincipal;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class StompEventListener {
+
+    private final MessageReadStatusService messageReadStatusService;
+
+    // websocket 구독시 호출
+    @EventListener
+    public void handleWebSocketConnectListener(SessionSubscribeEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+
+        WebSocketPrincipal user = (WebSocketPrincipal) headerAccessor.getUser();
+
+        Long matchingId = getMatchingIdFromDestination(headerAccessor);
+        user.setMatchingId(matchingId);
+
+        messageReadStatusService.updateLastReadTime(matchingId, user.getSenderId());
+    }
+
+    private Long getMatchingIdFromDestination(StompHeaderAccessor headerAccessor) {
+        String destination = headerAccessor.getDestination();
+        String matchingIdStr = destination.substring(destination.lastIndexOf("/") + 1);
+        return Long.parseLong(matchingIdStr);
+    }
+
+    // websocket 연결 종료시 호출
+    @EventListener
+    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+
+        WebSocketPrincipal user = (WebSocketPrincipal) headerAccessor.getUser();
+
+        Long memberId = user.getSenderId();
+        Long matchingId = user.getMatchingId();
+
+        messageReadStatusService.updateLastReadTime(matchingId, memberId);
+    }
+}

--- a/src/main/java/econo/buddybridge/matching/dto/MatchingParticipants.java
+++ b/src/main/java/econo/buddybridge/matching/dto/MatchingParticipants.java
@@ -1,0 +1,10 @@
+package econo.buddybridge.matching.dto;
+
+import econo.buddybridge.member.entity.Member;
+
+public record MatchingParticipants(
+        Member taker,
+        Member giver
+) {
+
+}

--- a/src/main/java/econo/buddybridge/matching/dto/MatchingResDto.java
+++ b/src/main/java/econo/buddybridge/matching/dto/MatchingResDto.java
@@ -17,7 +17,7 @@ public record MatchingResDto(
         MessageType messageType,
         MatchingStatus matchingStatus,
         ReceiverDto receiver,
-        Long unreadCount
+        Long unreadMessagesCount
 ) {
 
     @QueryProjection

--- a/src/main/java/econo/buddybridge/matching/dto/MatchingResDto.java
+++ b/src/main/java/econo/buddybridge/matching/dto/MatchingResDto.java
@@ -16,7 +16,8 @@ public record MatchingResDto(
         LocalDateTime lastMessageTime,
         MessageType messageType,
         MatchingStatus matchingStatus,
-        ReceiverDto receiver
+        ReceiverDto receiver,
+        Long unreadCount
 ) {
 
     @QueryProjection

--- a/src/main/java/econo/buddybridge/matching/entity/Matching.java
+++ b/src/main/java/econo/buddybridge/matching/entity/Matching.java
@@ -2,6 +2,7 @@ package econo.buddybridge.matching.entity;
 
 import econo.buddybridge.chat.chatmessage.entity.ChatMessage;
 import econo.buddybridge.common.persistence.SoftDeletableEntity;
+import econo.buddybridge.matching.exception.MatchingNotParticipantException;
 import econo.buddybridge.member.entity.Member;
 import econo.buddybridge.post.entity.Post;
 import jakarta.persistence.CascadeType;
@@ -64,5 +65,11 @@ public class Matching extends SoftDeletableEntity {
 
     public void updateMatchingStatus(MatchingStatus matchingStatus) {
         this.matchingStatus = matchingStatus;
+    }
+
+    public void validateParticipants(Member member) {
+        if (!taker.equals(member) && !giver.equals(member)) {
+            throw MatchingNotParticipantException.EXCEPTION;
+        }
     }
 }

--- a/src/main/java/econo/buddybridge/matching/exception/MatchingErrorCode.java
+++ b/src/main/java/econo/buddybridge/matching/exception/MatchingErrorCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 public enum MatchingErrorCode implements ErrorCode {
     MATCHING_NOT_FOUND("MA001", HttpStatus.NOT_FOUND, "존재하지 않는 매칭입니다."),
     MATCHING_UNAUTHORIZED_ACCESS("MA002", HttpStatus.FORBIDDEN, "사용자가 생성한 매칭방이 아닙니다."),
-    MATCHING_COMPLETED("MA003", HttpStatus.BAD_REQUEST, "모집이 완료되었습니다.")
+    MATCHING_COMPLETED("MA003", HttpStatus.BAD_REQUEST, "모집이 완료되었습니다."),
+    MATCHING_NOT_PARTICIPANT("MA004", HttpStatus.FORBIDDEN, "매칭에 참여한 사용자가 아닙니다."),
     ;
 
     private final String code;

--- a/src/main/java/econo/buddybridge/matching/exception/MatchingNotParticipantException.java
+++ b/src/main/java/econo/buddybridge/matching/exception/MatchingNotParticipantException.java
@@ -1,0 +1,12 @@
+package econo.buddybridge.matching.exception;
+
+import econo.buddybridge.common.exception.BusinessException;
+
+public class MatchingNotParticipantException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new MatchingNotParticipantException();
+
+    private MatchingNotParticipantException() {
+        super(MatchingErrorCode.MATCHING_NOT_PARTICIPANT);
+    }
+}

--- a/src/main/java/econo/buddybridge/matching/repository/MatchingRepositoryCustomImpl.java
+++ b/src/main/java/econo/buddybridge/matching/repository/MatchingRepositoryCustomImpl.java
@@ -1,6 +1,7 @@
 package econo.buddybridge.matching.repository;
 
 import static econo.buddybridge.chat.chatmessage.entity.QChatMessage.chatMessage;
+import static econo.buddybridge.chat.chatmessage.entity.QMessageReadStatus.messageReadStatus;
 import static econo.buddybridge.matching.entity.QMatching.matching;
 import static econo.buddybridge.member.entity.QMember.member;
 
@@ -45,15 +46,30 @@ public class MatchingRepositoryCustomImpl implements MatchingRepositoryCustom {
                                 member.id,
                                 member.name,
                                 member.profileImageUrl
-                        )
+                        ),
+                        JPAExpressions
+                                .select(subChatMessage.id.count())          // 읽지 않은 메시지 수
+                                .from(subChatMessage)
+                                .where(subChatMessage.matching.eq(matching)         // 해당 매칭방의 메시지 중
+                                        .and(subChatMessage.sender.id.ne(memberId)) // 내가 보낸 메시지는 제외하고
+                                        .and(subChatMessage.createdAt.gt(           // 마지막 읽은 시간 이후 메시지
+                                                JPAExpressions
+                                                        .select(messageReadStatus.lastReadTime)
+                                                        .from(messageReadStatus)
+                                                        .where(messageReadStatus.reader.id.eq(memberId)
+                                                                .and(messageReadStatus.matching.eq(matching)))
+                                        ))
+                                )
                 ))
                 .from(matching)
-                .leftJoin(chatMessage).on(chatMessage.matching.eq(matching)
-                        .and(chatMessage.id.eq(JPAExpressions
-                                .select(subChatMessage.id.max())
-                                .from(subChatMessage)
-                                .where(subChatMessage.matching.eq(matching)))))
-                .leftJoin(member).on(
+                .leftJoin(chatMessage).on(chatMessage.matching.eq(matching) // 마지막 메시지 정보
+                        .and(chatMessage.id.eq(
+                                JPAExpressions
+                                        .select(subChatMessage.id.max())
+                                        .from(subChatMessage)
+                                        .where(subChatMessage.matching.eq(matching)))
+                        ))
+                .leftJoin(member).on(   // 상대방 정보
                         member.id.eq(
                                 new CaseBuilder()
                                         .when(matching.taker.id.eq(memberId)).then(matching.giver.id)
@@ -61,12 +77,12 @@ public class MatchingRepositoryCustomImpl implements MatchingRepositoryCustom {
                         )
                 )
                 .where(
-                        matching.taker.id.eq(memberId).or(matching.giver.id.eq(memberId)),
+                        matching.taker.id.eq(memberId).or(matching.giver.id.eq(memberId)),  // 내가 참여한 매칭
                         buildCursorExpression(cursor),
                         buildMatchingStatusExpression(matchingStatus)
                 )
-                .orderBy(chatMessage.createdAt.desc())
-                .limit(size + 1)
+                .orderBy(chatMessage.createdAt.desc())  // 최신 메시지 순
+                .limit(size + 1L)
                 .fetch();
 
         boolean nextPage = false;

--- a/src/main/java/econo/buddybridge/matching/service/MatchingRoomService.java
+++ b/src/main/java/econo/buddybridge/matching/service/MatchingRoomService.java
@@ -60,7 +60,7 @@ public class MatchingRoomService {
         boolean nextPage = chatMessagesWithCursor.nextPage();
 
         Post post = matching.getPost();
-        return new ChatMessageCustomPage(post.getPostType(), post.getId(), receiverDto, chatMessageResDtos, nextCursor, nextPage);
+        return new ChatMessageCustomPage(post.getPostType(), post.getId(), post.getAuthor().getId(), receiverDto, chatMessageResDtos, nextCursor, nextPage);
     }
 
     private Member getReceiver(Matching matching, Long memberId) {

--- a/src/main/java/econo/buddybridge/matching/service/MatchingRoomService.java
+++ b/src/main/java/econo/buddybridge/matching/service/MatchingRoomService.java
@@ -60,7 +60,7 @@ public class MatchingRoomService {
         boolean nextPage = chatMessagesWithCursor.nextPage();
 
         Post post = matching.getPost();
-        return new ChatMessageCustomPage(post.getPostType(), post.getId(), post.getAuthor().getId(), receiverDto, chatMessageResDtos, nextCursor, nextPage);
+        return ChatMessageCustomPage.of(post, receiverDto, chatMessageResDtos, nextCursor, nextPage);
     }
 
     private Member getReceiver(Matching matching, Long memberId) {

--- a/src/main/java/econo/buddybridge/matching/service/MatchingService.java
+++ b/src/main/java/econo/buddybridge/matching/service/MatchingService.java
@@ -104,12 +104,12 @@ public class MatchingService {
 
     private void saveFirstChatMessage(Matching matching, Member author) {
         chatMessageRepository.save(
-                ChatMessage.builder()
-                        .matching(matching)
-                        .content("매칭이 생성되었습니다. 채팅을 통해 상대방과 연락해보세요!")
-                        .messageType(MessageType.INFO)
-                        .sender(author)
-                        .build()
+                ChatMessage.of(
+                        matching,
+                        author,
+                        "매칭이 생성되었습니다. 채팅을 통해 상대방과 연락해보세요!",
+                        MessageType.INFO
+                )
         );
     }
 

--- a/src/main/java/econo/buddybridge/matching/service/MatchingService.java
+++ b/src/main/java/econo/buddybridge/matching/service/MatchingService.java
@@ -1,8 +1,11 @@
 package econo.buddybridge.matching.service;
 
 import econo.buddybridge.chat.chatmessage.entity.ChatMessage;
+import econo.buddybridge.chat.chatmessage.entity.MessageReadStatus;
 import econo.buddybridge.chat.chatmessage.entity.MessageType;
 import econo.buddybridge.chat.chatmessage.repository.ChatMessageRepository;
+import econo.buddybridge.chat.chatmessage.repository.MessageReadStatusRepository;
+import econo.buddybridge.matching.dto.MatchingParticipants;
 import econo.buddybridge.matching.dto.MatchingReqDto;
 import econo.buddybridge.matching.dto.MatchingUpdateDto;
 import econo.buddybridge.matching.entity.Matching;
@@ -16,6 +19,8 @@ import econo.buddybridge.member.service.MemberService;
 import econo.buddybridge.post.entity.Post;
 import econo.buddybridge.post.entity.PostType;
 import econo.buddybridge.post.service.PostService;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -26,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MatchingService {
 
     private final ChatMessageRepository chatMessageRepository;
+    private final MessageReadStatusRepository messageReadStatusRepository;
     private final MatchingRepository matchingRepository;
     private final MemberService memberService;
     private final PostService postService;
@@ -53,11 +59,29 @@ public class MatchingService {
     @Transactional
     public Long createMatchingById(MatchingReqDto matchingReqDto, Long memberId) {
         Post post = postService.findPostByIdOrThrow(matchingReqDto.postId());
+        if (existsMatchingDone(post)) {
+            throw MatchingCompletedException.EXCEPTION;
+        }
+
         Member author = memberService.findMemberByIdOrThrow(memberId);
-        validatePostAuthor(post, author);
         post.validateAuthor(author);
 
-        Member taker, giver;
+        MatchingParticipants participants = resolveParticipants(post, author, matchingReqDto);
+        Member taker = participants.taker();
+        Member giver = participants.giver();
+
+        Matching matching = matchingReqToMatching(post, taker, giver);
+        Matching savedMatching = matchingRepository.save(matching);
+
+        initMessageReadStatus(savedMatching, taker, giver); // 마지막으로 읽은 시간 초기화
+        saveFirstChatMessage(matching, author);             // 채팅방 생성 메시지 저장
+
+        return savedMatching.getId();
+    }
+
+    private MatchingParticipants resolveParticipants(Post post, Member author, MatchingReqDto matchingReqDto) {
+        Member taker;
+        Member giver;
 
         if (post.getPostType() == PostType.GIVER) {
             giver = author;
@@ -67,15 +91,15 @@ public class MatchingService {
             taker = author;
         }
 
-        if (existsMatchingDone(post)) {
-            throw MatchingCompletedException.EXCEPTION;
-        }
+        return new MatchingParticipants(taker, giver);
+    }
 
-        Matching matching = matchingReqToMatching(post, taker, giver);
-
-        saveFirstChatMessage(matching, taker);
-
-        return matchingRepository.save(matching).getId();
+    private void initMessageReadStatus(Matching savedMatching, Member taker, Member giver) {
+        LocalDateTime now = LocalDateTime.now();
+        messageReadStatusRepository.saveAll(List.of(
+                MessageReadStatus.of(savedMatching, taker, now),
+                MessageReadStatus.of(savedMatching, giver, now)
+        ));
     }
 
     private void saveFirstChatMessage(Matching matching, Member author) {

--- a/src/main/java/econo/buddybridge/matching/service/MatchingService.java
+++ b/src/main/java/econo/buddybridge/matching/service/MatchingService.java
@@ -15,7 +15,6 @@ import econo.buddybridge.member.entity.Member;
 import econo.buddybridge.member.service.MemberService;
 import econo.buddybridge.post.entity.Post;
 import econo.buddybridge.post.entity.PostType;
-import econo.buddybridge.post.exception.PostUnauthorizedAccessException;
 import econo.buddybridge.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -56,6 +55,7 @@ public class MatchingService {
         Post post = postService.findPostByIdOrThrow(matchingReqDto.postId());
         Member author = memberService.findMemberByIdOrThrow(memberId);
         validatePostAuthor(post, author);
+        post.validateAuthor(author);
 
         Member taker, giver;
 
@@ -78,13 +78,13 @@ public class MatchingService {
         return matchingRepository.save(matching).getId();
     }
 
-    private void saveFirstChatMessage(Matching matching, Member taker) {
+    private void saveFirstChatMessage(Matching matching, Member author) {
         chatMessageRepository.save(
                 ChatMessage.builder()
                         .matching(matching)
                         .content("매칭이 생성되었습니다. 채팅을 통해 상대방과 연락해보세요!")
                         .messageType(MessageType.INFO)
-                        .sender(taker)
+                        .sender(author)
                         .build()
         );
     }
@@ -94,7 +94,8 @@ public class MatchingService {
         Matching matching = findMatchingByIdOrThrow(matchingId);
         Post post = postService.findPostByIdOrThrow(matching.getPost().getId());
         Member author = memberService.findMemberByIdOrThrow(memberId);
-        validatePostAuthor(post, author);
+
+        post.validateAuthor(author);
 
         MatchingStatus updateStatus = matchingUpdateDto.matchingStatus();
 
@@ -116,7 +117,8 @@ public class MatchingService {
     public void deleteMatching(Long matchingId, Long memberId) {
         Matching matching = findMatchingByIdOrThrow(matchingId);
         Member author = memberService.findMemberByIdOrThrow(memberId);
-        validatePostAuthor(matching.getPost(), author);
+
+        matching.getPost().validateAuthor(author);
 
         publisher.publishEvent(MatchingDeleteEvent.from(matching));
     }
@@ -129,12 +131,5 @@ public class MatchingService {
                 .giver(giver)
                 .matchingStatus(MatchingStatus.PENDING) // 매칭 생성시 PENDING
                 .build();
-    }
-
-    // 게시글 작성 회원과 현재 로그인한 회원 일치 여부 판단
-    private void validatePostAuthor(Post post, Member author) {
-        if (!post.getAuthor().equals(author)) {
-            throw PostUnauthorizedAccessException.EXCEPTION;
-        }
     }
 }

--- a/src/main/java/econo/buddybridge/post/entity/Post.java
+++ b/src/main/java/econo/buddybridge/post/entity/Post.java
@@ -8,6 +8,7 @@ import econo.buddybridge.member.entity.DisabilityType;
 import econo.buddybridge.member.entity.Gender;
 import econo.buddybridge.member.entity.Member;
 import econo.buddybridge.post.dto.PostUpdateReqDto;
+import econo.buddybridge.post.exception.PostUnauthorizedAccessException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -82,6 +83,12 @@ public class Post extends SoftDeletableEntity {
 
     @OneToMany(mappedBy = "post", orphanRemoval = true, cascade = CascadeType.ALL)
     private final List<Comment> comments = new ArrayList<>();
+
+    public void validateAuthor(Member author) {
+        if (!this.author.equals(author)) {
+            throw PostUnauthorizedAccessException.EXCEPTION;
+        }
+    }
 
     public void updatePost(PostUpdateReqDto postUpdateReqDto) {
         Schedule updateSchedule = null;

--- a/src/main/java/econo/buddybridge/websocket/WebSocketPrincipal.java
+++ b/src/main/java/econo/buddybridge/websocket/WebSocketPrincipal.java
@@ -1,16 +1,18 @@
 package econo.buddybridge.websocket;
 
-import lombok.Getter;
-
 import java.security.Principal;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class WebSocketPrincipal implements Principal {
-    private final Long senderId;
 
-    private WebSocketPrincipal(Long senderId) {
-        this.senderId = senderId;
-    }
+    private final Long senderId;
+    private Long matchingId;
 
     public static WebSocketPrincipal of(Long senderId) {
         return new WebSocketPrincipal(senderId);


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

채팅 페이지에서 채팅방 목록에 안읽은 메시지 개수도 반환하도록 변경

- 채팅방에 대해 사용자가 마지막으로 채팅방을 읽은 시점 저장
- 채팅방 목록 반환 시 사용자가 마지막으로 읽은 시점 이후에 온 채팅 개수를 함께 반환
- 채팅방 연결(Subscribe) 및 연결 해제(Disconnect) 시 마지막으로 읽은 시점 갱신

## 관련 이슈

close #237 

## 체크리스트

- [x] 코드가 제대로 작동하는지 확인
- [x] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [x] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
