### PR TITLE
[FEAT] 게시글 다중 삭제

### DIFF
--- a/src/main/java/econo/buddybridge/comment/service/CommentService.java
+++ b/src/main/java/econo/buddybridge/comment/service/CommentService.java
@@ -1,5 +1,8 @@
 package econo.buddybridge.comment.service;
 
+import static econo.buddybridge.common.consts.BuddyBridgeStatic.COMMENT_NOTIFICATION_MESSAGE;
+import static econo.buddybridge.common.consts.BuddyBridgeStatic.getCommentNotificationUrl;
+
 import econo.buddybridge.comment.dto.CommentCustomPage;
 import econo.buddybridge.comment.dto.CommentReqDto;
 import econo.buddybridge.comment.dto.MyPageCommentCustomPage;
@@ -9,8 +12,6 @@ import econo.buddybridge.comment.exception.CommentAlreadyWrittenException;
 import econo.buddybridge.comment.exception.CommentDeleteNotAllowedException;
 import econo.buddybridge.comment.exception.CommentInvalidDirectionException;
 import econo.buddybridge.comment.exception.CommentNotFoundException;
-import econo.buddybridge.comment.exception.CommentSameGenderOnlyException;
-import econo.buddybridge.comment.exception.CommentSelfNotAllowedException;
 import econo.buddybridge.comment.exception.CommentUpdateNotAllowedException;
 import econo.buddybridge.comment.repository.CommentRepository;
 import econo.buddybridge.member.entity.Member;
@@ -27,9 +28,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import static econo.buddybridge.common.consts.BuddyBridgeStatic.COMMENT_NOTIFICATION_MESSAGE;
-import static econo.buddybridge.common.consts.BuddyBridgeStatic.getCommentNotificationUrl;
 
 @Service
 @RequiredArgsConstructor
@@ -67,14 +65,7 @@ public class CommentService {
         Member author = memberService.findMemberByIdOrThrow(memberId);
         Post post = postService.findPostByIdOrThrow(postId);
 
-        if (post.getGender() != author.getGender()) {
-            throw CommentSameGenderOnlyException.EXCEPTION;
-        }
-
-        // 본인의 게시글에 댓글 작성 불가
-        if (post.getAuthor().equals(author)) {
-            throw CommentSelfNotAllowedException.EXCEPTION;
-        }
+        post.validateCommentBy(author);
 
         // 기존에 댓글을 작성한 적이 있는지 확인하고 있다면 댓글 작성 불가
         if (commentRepository.existsByPostAndAuthor(post, author)) {

--- a/src/main/java/econo/buddybridge/post/controller/PostController.java
+++ b/src/main/java/econo/buddybridge/post/controller/PostController.java
@@ -8,6 +8,7 @@ import econo.buddybridge.post.dto.PostDetailDto;
 import econo.buddybridge.post.dto.PostEnumResDto;
 import econo.buddybridge.post.dto.PostReqDto;
 import econo.buddybridge.post.dto.PostUpdateReqDto;
+import econo.buddybridge.post.dto.PostsDeleteRequest;
 import econo.buddybridge.post.entity.AssistanceType;
 import econo.buddybridge.post.entity.PostStatus;
 import econo.buddybridge.post.entity.PostType;
@@ -135,6 +136,16 @@ public class PostController {
             @Parameter(hidden = true) @MemberTokenId Long memberId
     ) {
         postService.deletePost(postId, memberId);
+        return ApiResponseGenerator.success(HttpStatus.NO_CONTENT);
+    }
+
+    @Operation(summary = "게시글 다중 삭제", description = "게시글을 다중 삭제합니다.")
+    @DeleteMapping
+    public ApiResponse<ApiResponse.CustomBody<Void>> deletePosts(
+            @RequestBody @Valid PostsDeleteRequest postsDeleteRequest,
+            @Parameter(hidden = true) @MemberTokenId Long memberId
+    ) {
+        postService.deletePosts(postsDeleteRequest.postIds(), memberId);
         return ApiResponseGenerator.success(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/econo/buddybridge/post/dto/PostsDeleteRequest.java
+++ b/src/main/java/econo/buddybridge/post/dto/PostsDeleteRequest.java
@@ -1,0 +1,13 @@
+package econo.buddybridge.post.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record PostsDeleteRequest(
+        @NotNull(message = "삭제할 게시글 ID는 필수입니다.")
+        @Size(min = 1, message = "삭제할 게시글 ID는 최소 1개 이상이어야 합니다.")
+        List<Long> postIds
+) {
+
+}

--- a/src/main/java/econo/buddybridge/post/entity/Post.java
+++ b/src/main/java/econo/buddybridge/post/entity/Post.java
@@ -2,13 +2,17 @@ package econo.buddybridge.post.entity;
 
 
 import econo.buddybridge.comment.entity.Comment;
+import econo.buddybridge.comment.exception.CommentSameGenderOnlyException;
+import econo.buddybridge.comment.exception.CommentSelfNotAllowedException;
 import econo.buddybridge.common.persistence.SoftDeletableEntity;
 import econo.buddybridge.matching.entity.Matching;
 import econo.buddybridge.member.entity.DisabilityType;
 import econo.buddybridge.member.entity.Gender;
 import econo.buddybridge.member.entity.Member;
 import econo.buddybridge.post.dto.PostUpdateReqDto;
+import econo.buddybridge.post.exception.PostDeleteNotAllowedException;
 import econo.buddybridge.post.exception.PostUnauthorizedAccessException;
+import econo.buddybridge.post.exception.PostUpdateNotAllowedException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -87,6 +91,28 @@ public class Post extends SoftDeletableEntity {
     public void validateAuthor(Member author) {
         if (!this.author.equals(author)) {
             throw PostUnauthorizedAccessException.EXCEPTION;
+        }
+    }
+
+    public void validateUpdateBy(Member author) {
+        if (!this.author.equals(author)) {
+            throw PostUpdateNotAllowedException.EXCEPTION;
+        }
+    }
+
+    public void validateDeletionBy(Member author) {
+        if (!this.author.equals(author)) {
+            throw PostDeleteNotAllowedException.EXCEPTION;
+        }
+    }
+
+    public void validateCommentBy(Member author) {
+        if (this.author.equals(author)) {
+            throw CommentSelfNotAllowedException.EXCEPTION;
+        }
+
+        if (this.gender != author.getGender()) {
+            throw CommentSameGenderOnlyException.EXCEPTION;
         }
     }
 

--- a/src/main/java/econo/buddybridge/post/event/PostDeleteEvent.java
+++ b/src/main/java/econo/buddybridge/post/event/PostDeleteEvent.java
@@ -2,6 +2,7 @@ package econo.buddybridge.post.event;
 
 import econo.buddybridge.common.event.DomainEvent;
 import econo.buddybridge.post.entity.Post;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -10,9 +11,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostDeleteEvent extends DomainEvent {
 
-    private final Post post;
+    private final List<Post> posts;
 
-    public static PostDeleteEvent from(Post post) {
-        return new PostDeleteEvent(post);
+    public static PostDeleteEvent from(List<Post> posts) {
+        return new PostDeleteEvent(posts);
     }
 }

--- a/src/main/java/econo/buddybridge/post/event/handler/PostDeleteEventHandler.java
+++ b/src/main/java/econo/buddybridge/post/event/handler/PostDeleteEventHandler.java
@@ -4,6 +4,7 @@ import econo.buddybridge.post.entity.Post;
 import econo.buddybridge.post.event.PostDeleteEvent;
 import econo.buddybridge.post.repository.PostRepository;
 import econo.buddybridge.report.repository.PostReportRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -18,14 +19,17 @@ public class PostDeleteEventHandler {
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void handlePostDeleteEvent(PostDeleteEvent event) {
-        Post post = event.getPost();
+        List<Post> posts = event.getPosts();
 
+        List<Post> reportedPosts = postReportRepository.findByReportedPostIn(posts);
         // 신고된 게시글은 soft delete
+        reportedPosts.forEach(Post::delete);
+
         // 신고된 게시글이 아닌 경우 완전 삭제
-        if (postReportRepository.existsByReportedPost(post)) {
-            post.delete();
-        } else {
-            postRepository.delete(post);
-        }
+        posts = posts.stream()
+                .filter(post -> !reportedPosts.contains(post))
+                .toList();
+
+        postRepository.deleteAllInBatch(posts);
     }
 }

--- a/src/main/java/econo/buddybridge/post/repository/PostRepository.java
+++ b/src/main/java/econo/buddybridge/post/repository/PostRepository.java
@@ -1,6 +1,7 @@
 package econo.buddybridge.post.repository;
 
 import econo.buddybridge.post.entity.Post;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -21,4 +22,6 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
     @Override
     @Query("SELECT p FROM Post p WHERE p.id = :postId")
     Optional<Post> findById(@Param("postId") Long postId);
+
+    List<Post> findByIdIn(List<Long> postIds);
 }

--- a/src/main/java/econo/buddybridge/post/service/PostService.java
+++ b/src/main/java/econo/buddybridge/post/service/PostService.java
@@ -14,9 +14,7 @@ import econo.buddybridge.post.entity.Post;
 import econo.buddybridge.post.entity.PostStatus;
 import econo.buddybridge.post.entity.PostType;
 import econo.buddybridge.post.event.PostDeleteEvent;
-import econo.buddybridge.post.exception.PostDeleteNotAllowedException;
 import econo.buddybridge.post.exception.PostNotFoundException;
-import econo.buddybridge.post.exception.PostUpdateNotAllowedException;
 import econo.buddybridge.post.repository.PostRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -67,11 +65,9 @@ public class PostService {
         return postRepository.findPostsByLikes(memberId, page - 1, size, sort, postType);
     }
 
-    // 검증 과정 필요성 고려
     @Transactional // 게시글 생성
     public Long createPost(PostReqDto postReqDto, Long memberId) {
         Member member = memberService.findMemberByIdOrThrow(memberId);
-
         Post post = postReqDto.toEntity(member);
         return postRepository.save(post).getId();
     }
@@ -90,10 +86,7 @@ public class PostService {
         Post post = findPostByIdWithAuthorOrThrow(postId);
         Member author = memberService.findMemberByIdOrThrow(memberId);
 
-        if (!post.getAuthor().equals(author)) {
-            throw PostUpdateNotAllowedException.EXCEPTION;
-        }
-
+        post.validateUpdateBy(author);
         post.updatePost(postUpdateReqDto);
 
         return post.getId();
@@ -104,9 +97,7 @@ public class PostService {
         Post post = findPostByIdWithAuthorOrThrow(postId);
         Member author = memberService.findMemberByIdOrThrow(memberId);
 
-        if (!post.getAuthor().equals(author)) {
-            throw PostDeleteNotAllowedException.EXCEPTION;
-        }
+        post.validateDeletionBy(author);
 
         publisher.publishEvent(PostDeleteEvent.from(post));
     }

--- a/src/main/java/econo/buddybridge/post/service/PostService.java
+++ b/src/main/java/econo/buddybridge/post/service/PostService.java
@@ -99,6 +99,20 @@ public class PostService {
 
         post.validateDeletionBy(author);
 
-        publisher.publishEvent(PostDeleteEvent.from(post));
+        publisher.publishEvent(PostDeleteEvent.from(List.of(post)));
+    }
+
+    @Transactional  // 게시글 다중 삭제
+    public void deletePosts(List<Long> postIds, Long memberId) {
+        List<Post> posts = postRepository.findByIdIn(postIds);
+
+        if (posts.size() != postIds.size()) {
+            throw PostNotFoundException.EXCEPTION;
+        }
+
+        Member author = memberService.findMemberByIdOrThrow(memberId);
+        posts.forEach(post -> post.validateDeletionBy(author));
+
+        publisher.publishEvent(PostDeleteEvent.from(posts));
     }
 }

--- a/src/main/java/econo/buddybridge/report/repository/PostReportRepository.java
+++ b/src/main/java/econo/buddybridge/report/repository/PostReportRepository.java
@@ -3,11 +3,14 @@ package econo.buddybridge.report.repository;
 import econo.buddybridge.member.entity.Member;
 import econo.buddybridge.post.entity.Post;
 import econo.buddybridge.report.entity.PostReport;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PostReportRepository extends JpaRepository<PostReport, Long> {
 
     boolean existsByReportedPostAndReporter(Post reportedPost, Member reporter);
 
-    boolean existsByReportedPost(Post reportedPost);
+    @Query("SELECT pr.reportedPost FROM PostReport pr WHERE pr.reportedPost IN :reportedPosts")
+    List<Post> findByReportedPostIn(List<Post> reportedPosts);
 }


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

게시글을 한 번에 여러개 삭제하는 기능 구현

## 참고 사항

- `deleteAllInBatch` 는 `JPQL`을 실행하기 때문에 실행 직전 영속성 컨텍스트가 `flush`됩니다. 따라서 해당 메서드 호출 직전에 `flush()`를 명시적으로 호출하지 않았습니다.  하지만, 상황에 따라 `flush` 되지 않는 경우도 존재합니다. 해당 부분은 블로그 링크 참고해주세요.

[[JPA] @Modifying의 flushAutomatically 옵션은 언제 쓰지?](https://velog.io/@gruzzimo/JPA-Modifying%EC%9D%98-flushAutomatically-%EC%98%B5%EC%85%98%EC%9D%80-%EC%96%B8%EC%A0%9C-%EC%93%B0%EC%A7%80)

## 관련 이슈

close #243 

## 체크리스트

- [x] 코드가 제대로 작동하는지 확인
- [x] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [x] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
