### PR TITLE
[FIX] 게시글 삭제 시 연관관계 엔티티 먼저 삭제

### DIFF
--- a/src/main/java/econo/buddybridge/chat/chatmessage/repository/ChatMessageRepository.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/repository/ChatMessageRepository.java
@@ -1,8 +1,11 @@
 package econo.buddybridge.chat.chatmessage.repository;
 
 import econo.buddybridge.chat.chatmessage.entity.ChatMessage;
+import econo.buddybridge.matching.entity.Matching;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>, ChatMessageRepositoryCustom {
 
+    Iterable<ChatMessage> findByMatchingIn(List<Matching> matchings);
 }

--- a/src/main/java/econo/buddybridge/chat/chatmessage/repository/MessageReadStatusRepository.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/repository/MessageReadStatusRepository.java
@@ -3,10 +3,13 @@ package econo.buddybridge.chat.chatmessage.repository;
 import econo.buddybridge.chat.chatmessage.entity.MessageReadStatus;
 import econo.buddybridge.matching.entity.Matching;
 import econo.buddybridge.member.entity.Member;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MessageReadStatusRepository extends JpaRepository<MessageReadStatus, Long> {
 
     Optional<MessageReadStatus> findByMatchingAndReader(Matching matching, Member reader);
+
+    List<MessageReadStatus> findByMatchingIn(List<Matching> matchings);
 }

--- a/src/main/java/econo/buddybridge/comment/repository/CommentRepository.java
+++ b/src/main/java/econo/buddybridge/comment/repository/CommentRepository.java
@@ -3,6 +3,7 @@ package econo.buddybridge.comment.repository;
 import econo.buddybridge.comment.entity.Comment;
 import econo.buddybridge.member.entity.Member;
 import econo.buddybridge.post.entity.Post;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -18,4 +19,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, Comment
     @Override
     @Query("SELECT c FROM Comment c WHERE c.id = :commentId")
     Optional<Comment> findById(@Param("commentId") Long commentId);
+
+    List<Comment> findByPostIn(List<Post> posts);
 }

--- a/src/main/java/econo/buddybridge/matching/repository/MatchingRepository.java
+++ b/src/main/java/econo/buddybridge/matching/repository/MatchingRepository.java
@@ -3,19 +3,16 @@ package econo.buddybridge.matching.repository;
 import econo.buddybridge.matching.entity.Matching;
 import econo.buddybridge.member.entity.Member;
 import econo.buddybridge.post.entity.Post;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.List;
-import java.util.Optional;
 
 public interface MatchingRepository extends JpaRepository<Matching, Long>, MatchingRepositoryCustom {
 
     @Query("SELECT m FROM Matching m JOIN FETCH m.post JOIN FETCH m.giver JOIN FETCH m.taker WHERE m.id = :matchingId")
     Optional<Matching> findByIdWithMembersAndPost(Long matchingId);
-
-    List<Matching> findByPostId(Long postId);
 
     @Query("SELECT m FROM Matching m JOIN FETCH m.giver JOIN FETCH m.taker WHERE m.id = :matchingId")
     Optional<Matching> findByIdWithMembers(@Param("matchingId") Long matchingId);
@@ -34,4 +31,6 @@ public interface MatchingRepository extends JpaRepository<Matching, Long>, Match
             @Param("firstMember") Member firstMember,
             @Param("secondMember") Member secondMember
     );
+
+    List<Matching> findByPostIn(List<Post> posts);
 }

--- a/src/main/java/econo/buddybridge/post/event/handler/PostDeleteEventHandler.java
+++ b/src/main/java/econo/buddybridge/post/event/handler/PostDeleteEventHandler.java
@@ -1,7 +1,15 @@
 package econo.buddybridge.post.event.handler;
 
+import econo.buddybridge.chat.chatmessage.repository.ChatMessageRepository;
+import econo.buddybridge.chat.chatmessage.repository.MessageReadStatusRepository;
+import econo.buddybridge.comment.entity.Comment;
+import econo.buddybridge.comment.repository.CommentRepository;
+import econo.buddybridge.matching.entity.Matching;
+import econo.buddybridge.matching.repository.MatchingRepository;
 import econo.buddybridge.post.entity.Post;
+import econo.buddybridge.post.entity.PostLike;
 import econo.buddybridge.post.event.PostDeleteEvent;
+import econo.buddybridge.post.repository.PostLikeRepository;
 import econo.buddybridge.post.repository.PostRepository;
 import econo.buddybridge.report.repository.PostReportRepository;
 import java.util.List;
@@ -16,6 +24,11 @@ public class PostDeleteEventHandler {
 
     private final PostReportRepository postReportRepository;
     private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final MatchingRepository matchingRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final MessageReadStatusRepository messageReadStatusRepository;
+    private final PostLikeRepository postLikeRepository;
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void handlePostDeleteEvent(PostDeleteEvent event) {
@@ -29,6 +42,17 @@ public class PostDeleteEventHandler {
         posts = posts.stream()
                 .filter(post -> !reportedPosts.contains(post))
                 .toList();
+
+        List<Matching> matchings = matchingRepository.findByPostIn(posts);
+        chatMessageRepository.deleteAllInBatch(chatMessageRepository.findByMatchingIn(matchings));
+        messageReadStatusRepository.deleteAllInBatch(messageReadStatusRepository.findByMatchingIn(matchings));
+        matchingRepository.deleteAllInBatch(matchings);
+
+        List<Comment> comments = commentRepository.findByPostIn(posts);
+        commentRepository.deleteAllInBatch(comments);
+
+        List<PostLike> postLikes = postLikeRepository.findByPostIn(posts);
+        postLikeRepository.deleteAllInBatch(postLikes);
 
         postRepository.deleteAllInBatch(posts);
     }

--- a/src/main/java/econo/buddybridge/post/repository/PostLikeRepository.java
+++ b/src/main/java/econo/buddybridge/post/repository/PostLikeRepository.java
@@ -1,8 +1,11 @@
 package econo.buddybridge.post.repository;
 
+import econo.buddybridge.post.entity.Post;
 import econo.buddybridge.post.entity.PostLike;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long>, PostLikeRepositoryCustom {
 
+    List<PostLike> findByPostIn(List<Post> posts);
 }


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

게시글 엔티티 다중삭제 시 연관된 엔티티부터 삭제

## 참고 사항

- `deleteAllInBatch`나 `@Modifying`을 사용한 배치 연산의 경우 데이터베이스로 쿼리가 날아가기 때문에 JPA에서 제공하는 `Cascade`가 적용되지 않습니다.
- 따라서 연관관계가 적용된 엔티티들을 우선 제거 후 게시글을 제거하도록 구현했습니다.

## 관련 이슈

fix #251 

## 체크리스트

- [x] 코드가 제대로 작동하는지 확인
- [x] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [x] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
