### PR TITLE
[REFACTOR] 게시글 다중 삭제 로직 IN 쿼리 개선 및 연관된 댓글, 매칭 신고에 따른 soft delete 적용

### DIFF
--- a/src/main/java/econo/buddybridge/chat/chatmessage/repository/ChatMessageRepository.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/repository/ChatMessageRepository.java
@@ -4,8 +4,12 @@ import econo.buddybridge.chat.chatmessage.entity.ChatMessage;
 import econo.buddybridge.matching.entity.Matching;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>, ChatMessageRepositoryCustom {
 
-    Iterable<ChatMessage> findByMatchingIn(List<Matching> matchings);
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("DELETE FROM ChatMessage cm WHERE cm.matching IN :matchings")
+    void deleteAllByMatchingIn(List<Matching> matchings);
 }

--- a/src/main/java/econo/buddybridge/chat/chatmessage/repository/MessageReadStatusRepository.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/repository/MessageReadStatusRepository.java
@@ -6,10 +6,14 @@ import econo.buddybridge.member.entity.Member;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MessageReadStatusRepository extends JpaRepository<MessageReadStatus, Long> {
 
     Optional<MessageReadStatus> findByMatchingAndReader(Matching matching, Member reader);
 
-    List<MessageReadStatus> findByMatchingIn(List<Matching> matchings);
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("DELETE FROM MessageReadStatus mrs WHERE mrs.matching IN :matchings")
+    void deleteAllByMatchingIn(List<Matching> matchings);
 }

--- a/src/main/java/econo/buddybridge/comment/repository/CommentRepository.java
+++ b/src/main/java/econo/buddybridge/comment/repository/CommentRepository.java
@@ -6,6 +6,7 @@ import econo.buddybridge.post.entity.Post;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -20,5 +21,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, Comment
     @Query("SELECT c FROM Comment c WHERE c.id = :commentId")
     Optional<Comment> findById(@Param("commentId") Long commentId);
 
-    List<Comment> findByPostIn(List<Post> posts);
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("DELETE FROM Comment c WHERE c.post IN :posts")
+    void deleteAllByPostIn(List<Post> posts);
 }

--- a/src/main/java/econo/buddybridge/post/event/handler/PostDeleteEventHandler.java
+++ b/src/main/java/econo/buddybridge/post/event/handler/PostDeleteEventHandler.java
@@ -2,17 +2,18 @@ package econo.buddybridge.post.event.handler;
 
 import econo.buddybridge.chat.chatmessage.repository.ChatMessageRepository;
 import econo.buddybridge.chat.chatmessage.repository.MessageReadStatusRepository;
-import econo.buddybridge.comment.entity.Comment;
 import econo.buddybridge.comment.repository.CommentRepository;
 import econo.buddybridge.matching.entity.Matching;
 import econo.buddybridge.matching.repository.MatchingRepository;
 import econo.buddybridge.post.entity.Post;
-import econo.buddybridge.post.entity.PostLike;
 import econo.buddybridge.post.event.PostDeleteEvent;
 import econo.buddybridge.post.repository.PostLikeRepository;
 import econo.buddybridge.post.repository.PostRepository;
+import econo.buddybridge.report.repository.CommentReportRepository;
+import econo.buddybridge.report.repository.MatchingReportRepository;
 import econo.buddybridge.report.repository.PostReportRepository;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -23,6 +24,9 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class PostDeleteEventHandler {
 
     private final PostReportRepository postReportRepository;
+    private final CommentReportRepository commentReportRepository;
+    private final MatchingReportRepository matchingReportRepository;
+
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
     private final MatchingRepository matchingRepository;
@@ -34,26 +38,33 @@ public class PostDeleteEventHandler {
     public void handlePostDeleteEvent(PostDeleteEvent event) {
         List<Post> posts = event.getPosts();
 
-        List<Post> reportedPosts = postReportRepository.findByReportedPostIn(posts);
+        Set<Post> reportedPosts = postReportRepository.findByReportedPostIn(posts);
+        Set<Post> reportedCommentPosts = commentReportRepository.findPostByReportedCommentPostIn(posts);
+        Set<Post> reportedMatchingPosts = matchingReportRepository.findPostByReportedMatchingPostIn(posts);
+
+        reportedPosts.addAll(reportedCommentPosts);
+        reportedPosts.addAll(reportedMatchingPosts);
+
         // 신고된 게시글은 soft delete
-        reportedPosts.forEach(Post::delete);
+        if (!reportedPosts.isEmpty()) {
+            postRepository.softDeleteAllIn(reportedPosts);
+        }
 
         // 신고된 게시글이 아닌 경우 완전 삭제
         posts = posts.stream()
                 .filter(post -> !reportedPosts.contains(post))
                 .toList();
 
-        List<Matching> matchings = matchingRepository.findByPostIn(posts);
-        chatMessageRepository.deleteAllInBatch(chatMessageRepository.findByMatchingIn(matchings));
-        messageReadStatusRepository.deleteAllInBatch(messageReadStatusRepository.findByMatchingIn(matchings));
-        matchingRepository.deleteAllInBatch(matchings);
+        if (!posts.isEmpty()) {
+            List<Matching> matchings = matchingRepository.findByPostIn(posts);
+            chatMessageRepository.deleteAllByMatchingIn(matchings);
+            messageReadStatusRepository.deleteAllByMatchingIn(matchings);
+            matchingRepository.deleteAllInBatch(matchings);
 
-        List<Comment> comments = commentRepository.findByPostIn(posts);
-        commentRepository.deleteAllInBatch(comments);
+            commentRepository.deleteAllByPostIn(posts);
+            postLikeRepository.deleteAllByPostIn(posts);
 
-        List<PostLike> postLikes = postLikeRepository.findByPostIn(posts);
-        postLikeRepository.deleteAllInBatch(postLikes);
-
-        postRepository.deleteAllInBatch(posts);
+            postRepository.deleteAllIn(posts);
+        }
     }
 }

--- a/src/main/java/econo/buddybridge/post/repository/PostLikeRepository.java
+++ b/src/main/java/econo/buddybridge/post/repository/PostLikeRepository.java
@@ -4,8 +4,12 @@ import econo.buddybridge.post.entity.Post;
 import econo.buddybridge.post.entity.PostLike;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long>, PostLikeRepositoryCustom {
 
-    List<PostLike> findByPostIn(List<Post> posts);
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("DELETE FROM PostLike pl WHERE pl.post IN :posts")
+    void deleteAllByPostIn(List<Post> posts);
 }

--- a/src/main/java/econo/buddybridge/post/repository/PostRepository.java
+++ b/src/main/java/econo/buddybridge/post/repository/PostRepository.java
@@ -3,7 +3,9 @@ package econo.buddybridge.post.repository;
 import econo.buddybridge.post.entity.Post;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -13,8 +15,7 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
     Optional<Post> findByIdWithAuthor(@Param("postId") Long postId);
 
     /**
-     * {@link @Filter} 어노테이션을 사용하기 위해서는 findById 메소드를 오버라이드 해야한다. <br>
-     * 일반 findById 메소드는 EntityMananger.find 메소드를 사용하기 때문에 @Filter 어노테이션 적용이 불가능하다.
+     * {@link @Filter} 어노테이션을 사용하기 위해서는 findById 메소드를 오버라이드 해야한다. <br> 일반 findById 메소드는 EntityMananger.find 메소드를 사용하기 때문에 @Filter 어노테이션 적용이 불가능하다.
      *
      * @param postId
      * @return
@@ -24,4 +25,12 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
     Optional<Post> findById(@Param("postId") Long postId);
 
     List<Post> findByIdIn(List<Long> postIds);
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("UPDATE Post p SET p.deleted = true WHERE p IN :posts")
+    void softDeleteAllIn(@Param("posts") Set<Post> posts);
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("DELETE FROM Post p WHERE p IN :posts")
+    void deleteAllIn(@Param("posts") List<Post> posts);
 }

--- a/src/main/java/econo/buddybridge/report/repository/CommentReportRepository.java
+++ b/src/main/java/econo/buddybridge/report/repository/CommentReportRepository.java
@@ -2,12 +2,19 @@ package econo.buddybridge.report.repository;
 
 import econo.buddybridge.comment.entity.Comment;
 import econo.buddybridge.member.entity.Member;
+import econo.buddybridge.post.entity.Post;
 import econo.buddybridge.report.entity.CommentReport;
+import java.util.List;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CommentReportRepository extends JpaRepository<CommentReport, Long> {
 
     boolean existsByReportedCommentAndReporter(Comment comment, Member member);
 
     boolean existsByReportedComment(Comment reportedComment);
+
+    @Query("SELECT cr.reportedComment.post FROM CommentReport cr WHERE cr.reportedComment.post IN :posts")
+    Set<Post> findPostByReportedCommentPostIn(List<Post> posts);
 }

--- a/src/main/java/econo/buddybridge/report/repository/MatchingReportRepository.java
+++ b/src/main/java/econo/buddybridge/report/repository/MatchingReportRepository.java
@@ -2,12 +2,19 @@ package econo.buddybridge.report.repository;
 
 import econo.buddybridge.matching.entity.Matching;
 import econo.buddybridge.member.entity.Member;
+import econo.buddybridge.post.entity.Post;
 import econo.buddybridge.report.entity.MatchingReport;
+import java.util.List;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MatchingReportRepository extends JpaRepository<MatchingReport, Long> {
 
     boolean existsByReportedMatchingAndReporter(Matching matching, Member member);
 
     boolean existsByReportedMatching(Matching reportedMatching);
+
+    @Query("SELECT m.reportedMatching.post FROM MatchingReport m WHERE m.reportedMatching.post IN :posts")
+    Set<Post> findPostByReportedMatchingPostIn(List<Post> posts);
 }

--- a/src/main/java/econo/buddybridge/report/repository/PostReportRepository.java
+++ b/src/main/java/econo/buddybridge/report/repository/PostReportRepository.java
@@ -4,6 +4,7 @@ import econo.buddybridge.member.entity.Member;
 import econo.buddybridge.post.entity.Post;
 import econo.buddybridge.report.entity.PostReport;
 import java.util.List;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -12,5 +13,5 @@ public interface PostReportRepository extends JpaRepository<PostReport, Long> {
     boolean existsByReportedPostAndReporter(Post reportedPost, Member reporter);
 
     @Query("SELECT pr.reportedPost FROM PostReport pr WHERE pr.reportedPost IN :reportedPosts")
-    List<Post> findByReportedPostIn(List<Post> reportedPosts);
+    Set<Post> findByReportedPostIn(List<Post> reportedPosts);
 }


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

- 게시글 다중 삭제 시 In 쿼리 적용 (기존의 deleteAllInBatch는 where 절 or 사용)
- 게시글에 해당하는 댓글과 매칭이 신고된 경우에도 soft delete 적용

## 참고 사항

- `deleteAllInBatch`는 조회 후 삭제 였다면 이제는 바로 삭제

## 관련 이슈

close #256 

## 체크리스트

- [x] 코드가 제대로 작동하는지 확인
- [x] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [x] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
