### PR TITLE
[FIX] 게시글 생성 시 assistanceStartTime에 assistanceEndTime이 잘못 저장되는 버그 수정

### DIFF
--- a/src/main/java/econo/buddybridge/post/mapper/PostMapper.java
+++ b/src/main/java/econo/buddybridge/post/mapper/PostMapper.java
@@ -39,7 +39,7 @@ public final class PostMapper {
                 .gender(author.getGender())
                 .age(author.getAge())
                 .assistanceTime(AssistanceTime.builder()
-                        .assistanceStartTime(request.assistanceEndTime())
+                        .assistanceStartTime(request.assistanceStartTime())
                         .assistanceEndTime(request.assistanceEndTime())
                         .build())
                 .build();


### PR DESCRIPTION
…장되는 버그 수정

## PR 유형

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

게시글 생성 시 `PostMapper#toEntity` assistanceStartTime에 assistanceEndTime이 잘못 저장되는 버그 수정

## 관련 이슈

close #264 

## 체크리스트

- [X] 코드가 제대로 작동하는지 확인
- [X] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [X] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
