### PR TITLE
[FIX] PostStatus 계산 시 완료 상태 범위 확장

### DIFF
--- a/src/main/java/econo/buddybridge/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/econo/buddybridge/post/repository/PostRepositoryImpl.java
@@ -1,5 +1,11 @@
 package econo.buddybridge.post.repository;
 
+import static econo.buddybridge.matching.entity.QMatching.matching;
+import static econo.buddybridge.post.entity.QPost.post;
+import static econo.buddybridge.post.entity.QPostLike.postLike;
+import static econo.buddybridge.post.mapper.PostMapper.toPostDetailDto;
+import static econo.buddybridge.post.mapper.PostMapper.toPostListItemDto;
+
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -16,8 +22,6 @@ import econo.buddybridge.post.entity.PostType;
 import econo.buddybridge.post.entity.QPost;
 import econo.buddybridge.post.exception.PostInvalidSortValueException;
 import econo.buddybridge.post.exception.PostNotFoundException;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -25,12 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static econo.buddybridge.matching.entity.QMatching.matching;
-import static econo.buddybridge.post.entity.QPost.post;
-import static econo.buddybridge.post.entity.QPostLike.postLike;
-import static econo.buddybridge.post.mapper.PostMapper.toPostDetailDto;
-import static econo.buddybridge.post.mapper.PostMapper.toPostListItemDto;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class PostRepositoryImpl implements PostRepositoryCustom {
@@ -87,7 +86,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 
     @Override // 게시글 목록 조회
     public PostCustomPage findPosts(Long memberId, Integer page, Integer size, String sort, PostType postType,
-                                    PostStatus postStatus, List<DisabilityType> disabilityType, List<AssistanceType> assistanceType) {
+            PostStatus postStatus, List<DisabilityType> disabilityType, List<AssistanceType> assistanceType) {
 
         List<Long> finishedPostIds = Collections.emptyList();
 
@@ -209,9 +208,11 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     }
 
     public PostStatus calculatePostStatus(List<Matching> matchings) {
+        List<MatchingStatus> matchingStatuses = MatchingStatus.getCompletedStatuses();
+
         return matchings
                 .stream()
-                .anyMatch(m -> m.getMatchingStatus() == MatchingStatus.DONE)
+                .anyMatch(m -> matchingStatuses.contains(m.getMatchingStatus()))
                 ? PostStatus.FINISHED
                 : PostStatus.RECRUITING;
     }


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

- PostStatus 계산 시 고려하는 MatchingStatus 범위 확장
- 기존: DONE 만 고려
- 추가: VOLUNTEERING_COMPLETED, VOLUNTEERING_VERIFIED 상태도 포함

## 관련 이슈

close #266 

## 체크리스트

- [X] 코드가 제대로 작동하는지 확인
- [X] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [X] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
