### PR TITLE
[FEAT] 봉사 인증 요청 보낸지 24시간이 지났는지 판단하는 필드 채팅방 응답에 추가

### DIFF
--- a/src/main/java/econo/buddybridge/chat/chatmessage/dto/ChatMessageCustomPage.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/dto/ChatMessageCustomPage.java
@@ -15,6 +15,7 @@ public record ChatMessageCustomPage(
         Long postAuthorId,
         ReceiverDto receiver,
         MatchingStatus matchingStatus,
+        Boolean canVerificationRequest,
         List<ChatMessageResDto> chatMessages,
         Long cursor,
         Boolean nextPage
@@ -27,6 +28,7 @@ public record ChatMessageCustomPage(
                 .postAuthorId(post.getAuthor().getId())
                 .receiver(receiver)
                 .matchingStatus(matching.getMatchingStatus())
+                .canVerificationRequest(matching.canRequestCertification())
                 .chatMessages(chatMessages)
                 .cursor(cursor)
                 .nextPage(nextPage)

--- a/src/main/java/econo/buddybridge/chat/chatmessage/service/ChatMessageService.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/service/ChatMessageService.java
@@ -44,15 +44,16 @@ public class ChatMessageService {
         Member sender = memberService.findMemberByIdOrThrow(memberId);
         Matching matching = matchingService.findByIdWithMembersAndPost(matchingId);
 
+        matching.validateVolunteerer(sender);
+        matching.validateMatchingStatusDone();
+
         LocalDateTime requestedAt = LocalDateTime.now();
 
         certificationTrackingRepository.findByMatchingIdWithMatching(matchingId)
                 .ifPresentOrElse(
-                        tracking -> validateAndUpdateTracking(tracking, requestedAt),
+                        tracking -> updateTracking(tracking, requestedAt),
                         () -> createNewTracking(matching, requestedAt)
                 );
-
-        matching.validateMatchingStatusDone(matching.getMatchingStatus());
 
         Long receiverId = getReceiverId(sender.getId(), matching.getId());
         Member receiver = memberService.findMemberByIdOrThrow(receiverId);
@@ -78,8 +79,7 @@ public class ChatMessageService {
         certificationTrackingRepository.save(newTracking);
     }
 
-    private void validateAndUpdateTracking(CertificationTracking tracking, LocalDateTime requestedAt) {
-        tracking.validateMatchingStatus(tracking.getMatching().getMatchingStatus());
+    private void updateTracking(CertificationTracking tracking, LocalDateTime requestedAt) {
         tracking.updateRequestedAt(requestedAt);
     }
 

--- a/src/main/java/econo/buddybridge/matching/entity/CertificationTracking.java
+++ b/src/main/java/econo/buddybridge/matching/entity/CertificationTracking.java
@@ -52,9 +52,14 @@ public class CertificationTracking {
     }
 
     public void updateRequestedAt(LocalDateTime requestedAt) {
-        if (!this.requestedAt.plusHours(24).isBefore(requestedAt)) {
+        if (!this.requestedAt.plusDays(1).isBefore(requestedAt)) {
             throw RequestCoolDownPeriodException.EXCEPTION;
         }
         this.requestedAt = requestedAt;
+    }
+
+    public boolean isRequestedWithinOneDay() {
+        LocalDateTime now = LocalDateTime.now();
+        return this.requestedAt.plusDays(1).isBefore(now);
     }
 }

--- a/src/main/java/econo/buddybridge/matching/entity/CertificationTracking.java
+++ b/src/main/java/econo/buddybridge/matching/entity/CertificationTracking.java
@@ -1,6 +1,5 @@
 package econo.buddybridge.matching.entity;
 
-import econo.buddybridge.matching.exception.certification.CertificationAlreadyCompletedException;
 import econo.buddybridge.matching.exception.certification.RequestCoolDownPeriodException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -43,12 +42,6 @@ public class CertificationTracking {
                 .matching(matching)
                 .requestedAt(requestedAt)
                 .build();
-    }
-
-    public void validateMatchingStatus(MatchingStatus matchingStatus) {
-        if (this.getMatching().getMatchingStatus() == matchingStatus) {
-            throw CertificationAlreadyCompletedException.EXCEPTION;
-        }
     }
 
     public void updateRequestedAt(LocalDateTime requestedAt) {

--- a/src/main/java/econo/buddybridge/matching/entity/Matching.java
+++ b/src/main/java/econo/buddybridge/matching/entity/Matching.java
@@ -28,6 +28,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.PostLoad;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
@@ -71,6 +72,9 @@ public class Matching extends SoftDeletableEntity {
     @OneToMany(mappedBy = "matching", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<ChatMessage> chatMessages = new ArrayList<>();
 
+    @OneToOne(mappedBy = "matching", cascade = CascadeType.ALL, orphanRemoval = true)
+    private CertificationTracking certificationTracking;
+
     @Builder
     public Matching(Post post, Member taker, Member giver, MatchingStatus matchingStatus) {
         this.post = post;
@@ -78,6 +82,10 @@ public class Matching extends SoftDeletableEntity {
         this.giver = giver;
         this.matchingStatus = matchingStatus;
         initializeMatchingState();
+    }
+
+    public boolean canRequestCertification() {
+        return certificationTracking.isRequestedWithinOneDay();
     }
 
     public void handleEvent(MatchingStatusChangeEvent event, MemberRole role) {

--- a/src/main/java/econo/buddybridge/matching/entity/Matching.java
+++ b/src/main/java/econo/buddybridge/matching/entity/Matching.java
@@ -110,8 +110,8 @@ public class Matching extends SoftDeletableEntity {
         }
     }
 
-    public void validateMatchingStatusDone(MatchingStatus matchingStatus) {
-        if (!this.matchingStatus.equals(matchingStatus)) {
+    public void validateMatchingStatusDone() {
+        if (!this.matchingStatus.equals(MatchingStatus.DONE)) {
             throw MatchingStatusNotDoneException.EXCEPTION;
         }
     }


### PR DESCRIPTION
## PR 유형

- [X] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

봉사 완료 요청 문자 보낸지 하루가 지났는지 판단하는 canVerificationRequest 필드 추가
GIVER(봉사자)가 아닌 경우 메시지 생성 됨 -> 안되게 변경

## 관련 이슈

close #297 

## 체크리스트

- [X] 코드가 제대로 작동하는지 확인
- [X] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [X] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
