### PR TITLE
Revert "[FEAT] 봉사 인증 요청 보낸지 24시간이 지났는지 판단하는 필드 채팅방 응답에 추가"

### DIFF
--- a/src/main/java/econo/buddybridge/chat/chatmessage/dto/ChatMessageCustomPage.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/dto/ChatMessageCustomPage.java
@@ -15,7 +15,6 @@ public record ChatMessageCustomPage(
         Long postAuthorId,
         ReceiverDto receiver,
         MatchingStatus matchingStatus,
-        Boolean canVerificationRequest,
         List<ChatMessageResDto> chatMessages,
         Long cursor,
         Boolean nextPage
@@ -28,7 +27,6 @@ public record ChatMessageCustomPage(
                 .postAuthorId(post.getAuthor().getId())
                 .receiver(receiver)
                 .matchingStatus(matching.getMatchingStatus())
-                .canVerificationRequest(matching.canRequestCertification())
                 .chatMessages(chatMessages)
                 .cursor(cursor)
                 .nextPage(nextPage)

--- a/src/main/java/econo/buddybridge/chat/chatmessage/service/ChatMessageService.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/service/ChatMessageService.java
@@ -44,16 +44,15 @@ public class ChatMessageService {
         Member sender = memberService.findMemberByIdOrThrow(memberId);
         Matching matching = matchingService.findByIdWithMembersAndPost(matchingId);
 
-        matching.validateVolunteerer(sender);
-        matching.validateMatchingStatusDone();
-
         LocalDateTime requestedAt = LocalDateTime.now();
 
         certificationTrackingRepository.findByMatchingIdWithMatching(matchingId)
                 .ifPresentOrElse(
-                        tracking -> updateTracking(tracking, requestedAt),
+                        tracking -> validateAndUpdateTracking(tracking, requestedAt),
                         () -> createNewTracking(matching, requestedAt)
                 );
+
+        matching.validateMatchingStatusDone(matching.getMatchingStatus());
 
         Long receiverId = getReceiverId(sender.getId(), matching.getId());
         Member receiver = memberService.findMemberByIdOrThrow(receiverId);
@@ -79,7 +78,8 @@ public class ChatMessageService {
         certificationTrackingRepository.save(newTracking);
     }
 
-    private void updateTracking(CertificationTracking tracking, LocalDateTime requestedAt) {
+    private void validateAndUpdateTracking(CertificationTracking tracking, LocalDateTime requestedAt) {
+        tracking.validateMatchingStatus(tracking.getMatching().getMatchingStatus());
         tracking.updateRequestedAt(requestedAt);
     }
 

--- a/src/main/java/econo/buddybridge/matching/entity/CertificationTracking.java
+++ b/src/main/java/econo/buddybridge/matching/entity/CertificationTracking.java
@@ -1,5 +1,6 @@
 package econo.buddybridge.matching.entity;
 
+import econo.buddybridge.matching.exception.certification.CertificationAlreadyCompletedException;
 import econo.buddybridge.matching.exception.certification.RequestCoolDownPeriodException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -44,15 +45,16 @@ public class CertificationTracking {
                 .build();
     }
 
+    public void validateMatchingStatus(MatchingStatus matchingStatus) {
+        if (this.getMatching().getMatchingStatus() == matchingStatus) {
+            throw CertificationAlreadyCompletedException.EXCEPTION;
+        }
+    }
+
     public void updateRequestedAt(LocalDateTime requestedAt) {
-        if (!this.requestedAt.plusDays(1).isBefore(requestedAt)) {
+        if (!this.requestedAt.plusHours(24).isBefore(requestedAt)) {
             throw RequestCoolDownPeriodException.EXCEPTION;
         }
         this.requestedAt = requestedAt;
-    }
-
-    public boolean isRequestedWithinOneDay() {
-        LocalDateTime now = LocalDateTime.now();
-        return this.requestedAt.plusDays(1).isBefore(now);
     }
 }

--- a/src/main/java/econo/buddybridge/matching/entity/Matching.java
+++ b/src/main/java/econo/buddybridge/matching/entity/Matching.java
@@ -28,7 +28,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.PostLoad;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
@@ -72,9 +71,6 @@ public class Matching extends SoftDeletableEntity {
     @OneToMany(mappedBy = "matching", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<ChatMessage> chatMessages = new ArrayList<>();
 
-    @OneToOne(mappedBy = "matching", cascade = CascadeType.ALL, orphanRemoval = true)
-    private CertificationTracking certificationTracking;
-
     @Builder
     public Matching(Post post, Member taker, Member giver, MatchingStatus matchingStatus) {
         this.post = post;
@@ -82,10 +78,6 @@ public class Matching extends SoftDeletableEntity {
         this.giver = giver;
         this.matchingStatus = matchingStatus;
         initializeMatchingState();
-    }
-
-    public boolean canRequestCertification() {
-        return certificationTracking.isRequestedWithinOneDay();
     }
 
     public void handleEvent(MatchingStatusChangeEvent event, MemberRole role) {
@@ -110,8 +102,8 @@ public class Matching extends SoftDeletableEntity {
         }
     }
 
-    public void validateMatchingStatusDone() {
-        if (!this.matchingStatus.equals(MatchingStatus.DONE)) {
+    public void validateMatchingStatusDone(MatchingStatus matchingStatus) {
+        if (!this.matchingStatus.equals(matchingStatus)) {
             throw MatchingStatusNotDoneException.EXCEPTION;
         }
     }


### PR DESCRIPTION
CertificationTracking 생성 시점이 사용자가 봉사 인증 요청을 하는 시점에 생겨 채팅을 읽을 때 CertificationTracking이 없어 에러 발생.

매칭이 생성될 때 CertificationTracking이 같이 생성되게 해야 함. 