### PR TITLE
[FIX] Matching 생성 시 CertificationTracking 생성되게 수정

### DIFF
--- a/src/main/java/econo/buddybridge/chat/chatmessage/dto/ChatMessageCustomPage.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/dto/ChatMessageCustomPage.java
@@ -15,6 +15,7 @@ public record ChatMessageCustomPage(
         Long postAuthorId,
         ReceiverDto receiver,
         MatchingStatus matchingStatus,
+        Boolean canVerificationRequest,
         List<ChatMessageResDto> chatMessages,
         Long cursor,
         Boolean nextPage
@@ -27,6 +28,7 @@ public record ChatMessageCustomPage(
                 .postAuthorId(post.getAuthor().getId())
                 .receiver(receiver)
                 .matchingStatus(matching.getMatchingStatus())
+                .canVerificationRequest(matching.canRequestCertification())
                 .chatMessages(chatMessages)
                 .cursor(cursor)
                 .nextPage(nextPage)

--- a/src/main/java/econo/buddybridge/chat/chatmessage/entity/MessageType.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/entity/MessageType.java
@@ -7,6 +7,7 @@ public enum MessageType {
     INFO("INFO"), // JOIN, LEAVE, ETC...
     CHAT("CHAT"),
     DELETE("DELETE"),
+    REQUEST("REQUEST"),
     ERROR("ERROR");
 
     private final String messageType;

--- a/src/main/java/econo/buddybridge/chat/chatmessage/service/ChatMessageService.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/service/ChatMessageService.java
@@ -44,15 +44,16 @@ public class ChatMessageService {
         Member sender = memberService.findMemberByIdOrThrow(memberId);
         Matching matching = matchingService.findByIdWithMembersAndPost(matchingId);
 
+        matching.validateVolunteerer(sender);
+        matching.validateMatchingStatusDone();
+
         LocalDateTime requestedAt = LocalDateTime.now();
 
         certificationTrackingRepository.findByMatchingIdWithMatching(matchingId)
                 .ifPresentOrElse(
-                        tracking -> validateAndUpdateTracking(tracking, requestedAt),
+                        tracking -> updateTracking(tracking, requestedAt),
                         () -> createNewTracking(matching, requestedAt)
                 );
-
-        matching.validateMatchingStatusDone(matching.getMatchingStatus());
 
         Long receiverId = getReceiverId(sender.getId(), matching.getId());
         Member receiver = memberService.findMemberByIdOrThrow(receiverId);
@@ -78,8 +79,7 @@ public class ChatMessageService {
         certificationTrackingRepository.save(newTracking);
     }
 
-    private void validateAndUpdateTracking(CertificationTracking tracking, LocalDateTime requestedAt) {
-        tracking.validateMatchingStatus(tracking.getMatching().getMatchingStatus());
+    private void updateTracking(CertificationTracking tracking, LocalDateTime requestedAt) {
         tracking.updateRequestedAt(requestedAt);
     }
 

--- a/src/main/java/econo/buddybridge/chat/chatmessage/service/ChatMessageService.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/service/ChatMessageService.java
@@ -59,7 +59,7 @@ public class ChatMessageService {
         Member receiver = memberService.findMemberByIdOrThrow(receiverId);
 
         String content = String.format("%s님이 '봉사 인증 요청'을 보냈습니다.", sender.getName());
-        ChatMessage chatMessage = ChatMessage.of(matching, sender, content, MessageType.INFO);
+        ChatMessage chatMessage = ChatMessage.of(matching, sender, content, MessageType.REQUEST);
         chatMessageRepository.save(chatMessage);
 
         sendNotification(receiver, sender, chatMessage, matching);

--- a/src/main/java/econo/buddybridge/matching/entity/CertificationTracking.java
+++ b/src/main/java/econo/buddybridge/matching/entity/CertificationTracking.java
@@ -52,9 +52,14 @@ public class CertificationTracking {
     }
 
     public void updateRequestedAt(LocalDateTime requestedAt) {
-        if (!this.requestedAt.plusHours(24).isBefore(requestedAt)) {
+        if (!this.requestedAt.plusDays(1).isBefore(requestedAt)) {
             throw RequestCoolDownPeriodException.EXCEPTION;
         }
         this.requestedAt = requestedAt;
+    }
+
+    public boolean isRequestedWithinOneDay() {
+        LocalDateTime now = LocalDateTime.now();
+        return this.requestedAt.plusDays(1).isBefore(now);
     }
 }

--- a/src/main/java/econo/buddybridge/matching/entity/CertificationTracking.java
+++ b/src/main/java/econo/buddybridge/matching/entity/CertificationTracking.java
@@ -3,11 +3,9 @@ package econo.buddybridge.matching.entity;
 import econo.buddybridge.matching.exception.certification.RequestCoolDownPeriodException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -26,20 +24,15 @@ public class CertificationTracking {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    private Matching matching;
-
     private LocalDateTime requestedAt;
 
     @Builder
-    private CertificationTracking(Matching matching, LocalDateTime requestedAt) {
-        this.matching = matching;
+    private CertificationTracking(LocalDateTime requestedAt) {
         this.requestedAt = requestedAt;
     }
 
-    public static CertificationTracking of(Matching matching, LocalDateTime requestedAt) {
+    public static CertificationTracking of(LocalDateTime requestedAt) {
         return CertificationTracking.builder()
-                .matching(matching)
                 .requestedAt(requestedAt)
                 .build();
     }

--- a/src/main/java/econo/buddybridge/matching/entity/CertificationTracking.java
+++ b/src/main/java/econo/buddybridge/matching/entity/CertificationTracking.java
@@ -1,6 +1,5 @@
 package econo.buddybridge.matching.entity;
 
-import econo.buddybridge.matching.exception.certification.CertificationAlreadyCompletedException;
 import econo.buddybridge.matching.exception.certification.RequestCoolDownPeriodException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -43,12 +42,6 @@ public class CertificationTracking {
                 .matching(matching)
                 .requestedAt(requestedAt)
                 .build();
-    }
-
-    public void validateMatchingStatus(MatchingStatus matchingStatus) {
-        if (this.getMatching().getMatchingStatus() == matchingStatus) {
-            throw CertificationAlreadyCompletedException.EXCEPTION;
-        }
     }
 
     public void updateRequestedAt(LocalDateTime requestedAt) {

--- a/src/main/java/econo/buddybridge/matching/entity/Matching.java
+++ b/src/main/java/econo/buddybridge/matching/entity/Matching.java
@@ -28,6 +28,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.PostLoad;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
@@ -71,6 +72,9 @@ public class Matching extends SoftDeletableEntity {
     @OneToMany(mappedBy = "matching", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<ChatMessage> chatMessages = new ArrayList<>();
 
+    @OneToOne(mappedBy = "matching", cascade = CascadeType.ALL, orphanRemoval = true)
+    private CertificationTracking certificationTracking;
+
     @Builder
     public Matching(Post post, Member taker, Member giver, MatchingStatus matchingStatus) {
         this.post = post;
@@ -78,6 +82,10 @@ public class Matching extends SoftDeletableEntity {
         this.giver = giver;
         this.matchingStatus = matchingStatus;
         initializeMatchingState();
+    }
+
+    public boolean canRequestCertification() {
+        return certificationTracking.isRequestedWithinOneDay();
     }
 
     public void handleEvent(MatchingStatusChangeEvent event, MemberRole role) {

--- a/src/main/java/econo/buddybridge/matching/entity/Matching.java
+++ b/src/main/java/econo/buddybridge/matching/entity/Matching.java
@@ -30,8 +30,10 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.PostLoad;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -82,6 +84,13 @@ public class Matching extends SoftDeletableEntity {
         this.giver = giver;
         this.matchingStatus = matchingStatus;
         initializeMatchingState();
+    }
+
+    private static final LocalDateTime INITIAL_REQUESTED_AT = LocalDateTime.of(2000, 1, 1, 0, 0, 0);
+
+    @PrePersist
+    private void prePersist() {
+        this.certificationTracking = CertificationTracking.of(this, INITIAL_REQUESTED_AT);
     }
 
     public boolean canRequestCertification() {

--- a/src/main/java/econo/buddybridge/matching/entity/Matching.java
+++ b/src/main/java/econo/buddybridge/matching/entity/Matching.java
@@ -30,7 +30,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.PostLoad;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import java.time.LocalDateTime;
@@ -83,14 +82,8 @@ public class Matching extends SoftDeletableEntity {
         this.taker = taker;
         this.giver = giver;
         this.matchingStatus = matchingStatus;
+        this.certificationTracking = CertificationTracking.of(LocalDateTime.now().plusDays(2));
         initializeMatchingState();
-    }
-
-    private static final LocalDateTime INITIAL_REQUESTED_AT = LocalDateTime.of(2000, 1, 1, 0, 0, 0);
-
-    @PrePersist
-    private void prePersist() {
-        this.certificationTracking = CertificationTracking.of(this, INITIAL_REQUESTED_AT);
     }
 
     public boolean canRequestCertification() {

--- a/src/main/java/econo/buddybridge/matching/entity/Matching.java
+++ b/src/main/java/econo/buddybridge/matching/entity/Matching.java
@@ -110,8 +110,8 @@ public class Matching extends SoftDeletableEntity {
         }
     }
 
-    public void validateMatchingStatusDone(MatchingStatus matchingStatus) {
-        if (!this.matchingStatus.equals(matchingStatus)) {
+    public void validateMatchingStatusDone() {
+        if (!this.matchingStatus.equals(MatchingStatus.DONE)) {
             throw MatchingStatusNotDoneException.EXCEPTION;
         }
     }


### PR DESCRIPTION
## PR 유형

- [X] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

- https://github.com/JNU-econovation/BuddyBridge_BE/pull/298 반영
- `Matching` 생성 시 `@PrePersist`를 통해 `CertificationTracking` 생성 및 초기화
- `MessageType`에 REQUEST 추가

## 참고 사항

`MatchingService` 에서 `CertificationTracking`을 생성 할 지 `@PrePersist`를 적용할 지 고민했는데 , `Matching`이 생성되면 `CertificationTracking`은 반드시 있어야 하며, `Matching`에 포함된 하나의 로직이라 생각해 `@PrePersist`를 적용시켰습니다.

## 관련 이슈

close #303 

## 체크리스트

- [X] 코드가 제대로 작동하는지 확인
- [X] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [X] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
