### PR TITLE
Revert "[FIX] Matching 생성 시 CertificationTracking 생성되게 수정"

### DIFF
--- a/src/main/java/econo/buddybridge/chat/chatmessage/dto/ChatMessageCustomPage.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/dto/ChatMessageCustomPage.java
@@ -15,7 +15,6 @@ public record ChatMessageCustomPage(
         Long postAuthorId,
         ReceiverDto receiver,
         MatchingStatus matchingStatus,
-        Boolean canVerificationRequest,
         List<ChatMessageResDto> chatMessages,
         Long cursor,
         Boolean nextPage
@@ -28,7 +27,6 @@ public record ChatMessageCustomPage(
                 .postAuthorId(post.getAuthor().getId())
                 .receiver(receiver)
                 .matchingStatus(matching.getMatchingStatus())
-                .canVerificationRequest(matching.canRequestCertification())
                 .chatMessages(chatMessages)
                 .cursor(cursor)
                 .nextPage(nextPage)

--- a/src/main/java/econo/buddybridge/chat/chatmessage/entity/MessageType.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/entity/MessageType.java
@@ -7,7 +7,6 @@ public enum MessageType {
     INFO("INFO"), // JOIN, LEAVE, ETC...
     CHAT("CHAT"),
     DELETE("DELETE"),
-    REQUEST("REQUEST"),
     ERROR("ERROR");
 
     private final String messageType;

--- a/src/main/java/econo/buddybridge/chat/chatmessage/service/ChatMessageService.java
+++ b/src/main/java/econo/buddybridge/chat/chatmessage/service/ChatMessageService.java
@@ -44,22 +44,21 @@ public class ChatMessageService {
         Member sender = memberService.findMemberByIdOrThrow(memberId);
         Matching matching = matchingService.findByIdWithMembersAndPost(matchingId);
 
-        matching.validateVolunteerer(sender);
-        matching.validateMatchingStatusDone();
-
         LocalDateTime requestedAt = LocalDateTime.now();
 
         certificationTrackingRepository.findByMatchingIdWithMatching(matchingId)
                 .ifPresentOrElse(
-                        tracking -> updateTracking(tracking, requestedAt),
+                        tracking -> validateAndUpdateTracking(tracking, requestedAt),
                         () -> createNewTracking(matching, requestedAt)
                 );
+
+        matching.validateMatchingStatusDone(matching.getMatchingStatus());
 
         Long receiverId = getReceiverId(sender.getId(), matching.getId());
         Member receiver = memberService.findMemberByIdOrThrow(receiverId);
 
         String content = String.format("%s님이 '봉사 인증 요청'을 보냈습니다.", sender.getName());
-        ChatMessage chatMessage = ChatMessage.of(matching, sender, content, MessageType.REQUEST);
+        ChatMessage chatMessage = ChatMessage.of(matching, sender, content, MessageType.INFO);
         chatMessageRepository.save(chatMessage);
 
         sendNotification(receiver, sender, chatMessage, matching);
@@ -79,7 +78,8 @@ public class ChatMessageService {
         certificationTrackingRepository.save(newTracking);
     }
 
-    private void updateTracking(CertificationTracking tracking, LocalDateTime requestedAt) {
+    private void validateAndUpdateTracking(CertificationTracking tracking, LocalDateTime requestedAt) {
+        tracking.validateMatchingStatus(tracking.getMatching().getMatchingStatus());
         tracking.updateRequestedAt(requestedAt);
     }
 

--- a/src/main/java/econo/buddybridge/matching/entity/CertificationTracking.java
+++ b/src/main/java/econo/buddybridge/matching/entity/CertificationTracking.java
@@ -1,11 +1,14 @@
 package econo.buddybridge.matching.entity;
 
+import econo.buddybridge.matching.exception.certification.CertificationAlreadyCompletedException;
 import econo.buddybridge.matching.exception.certification.RequestCoolDownPeriodException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -24,28 +27,34 @@ public class CertificationTracking {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    private Matching matching;
+
     private LocalDateTime requestedAt;
 
     @Builder
-    private CertificationTracking(LocalDateTime requestedAt) {
+    private CertificationTracking(Matching matching, LocalDateTime requestedAt) {
+        this.matching = matching;
         this.requestedAt = requestedAt;
     }
 
-    public static CertificationTracking of(LocalDateTime requestedAt) {
+    public static CertificationTracking of(Matching matching, LocalDateTime requestedAt) {
         return CertificationTracking.builder()
+                .matching(matching)
                 .requestedAt(requestedAt)
                 .build();
     }
 
+    public void validateMatchingStatus(MatchingStatus matchingStatus) {
+        if (this.getMatching().getMatchingStatus() == matchingStatus) {
+            throw CertificationAlreadyCompletedException.EXCEPTION;
+        }
+    }
+
     public void updateRequestedAt(LocalDateTime requestedAt) {
-        if (!this.requestedAt.plusDays(1).isBefore(requestedAt)) {
+        if (!this.requestedAt.plusHours(24).isBefore(requestedAt)) {
             throw RequestCoolDownPeriodException.EXCEPTION;
         }
         this.requestedAt = requestedAt;
-    }
-
-    public boolean isRequestedWithinOneDay() {
-        LocalDateTime now = LocalDateTime.now();
-        return this.requestedAt.plusDays(1).isBefore(now);
     }
 }

--- a/src/main/java/econo/buddybridge/matching/entity/Matching.java
+++ b/src/main/java/econo/buddybridge/matching/entity/Matching.java
@@ -28,11 +28,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.PostLoad;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -73,21 +71,13 @@ public class Matching extends SoftDeletableEntity {
     @OneToMany(mappedBy = "matching", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<ChatMessage> chatMessages = new ArrayList<>();
 
-    @OneToOne(mappedBy = "matching", cascade = CascadeType.ALL, orphanRemoval = true)
-    private CertificationTracking certificationTracking;
-
     @Builder
     public Matching(Post post, Member taker, Member giver, MatchingStatus matchingStatus) {
         this.post = post;
         this.taker = taker;
         this.giver = giver;
         this.matchingStatus = matchingStatus;
-        this.certificationTracking = CertificationTracking.of(LocalDateTime.now().plusDays(2));
         initializeMatchingState();
-    }
-
-    public boolean canRequestCertification() {
-        return certificationTracking.isRequestedWithinOneDay();
     }
 
     public void handleEvent(MatchingStatusChangeEvent event, MemberRole role) {
@@ -112,8 +102,8 @@ public class Matching extends SoftDeletableEntity {
         }
     }
 
-    public void validateMatchingStatusDone() {
-        if (!this.matchingStatus.equals(MatchingStatus.DONE)) {
+    public void validateMatchingStatusDone(MatchingStatus matchingStatus) {
+        if (!this.matchingStatus.equals(matchingStatus)) {
             throw MatchingStatusNotDoneException.EXCEPTION;
         }
     }


### PR DESCRIPTION
`CertificationTracking`이 `Matching`과 단방향 관계로 변경되면서 수정 안된 정적 팩토리 메서드 사용