### PR TITLE
[REFACTOR] 사용자 인증 폼 상세 조회 및 업데이트 요청 엔드포인트 변경

### DIFF
--- a/src/main/java/econo/buddybridge/auth/controller/OAuthController.java
+++ b/src/main/java/econo/buddybridge/auth/controller/OAuthController.java
@@ -71,6 +71,7 @@ public class OAuthController {
     }
 
     @Operation(summary = "카카오 소셜 로그인 (토큰으로 로그인)", description = "Redirect URL이 프론트엔드 주소로 설정될 때 사용합니다.")
+    @AllowAnonymous
     @PostMapping("/login")
     public ApiResponse<CustomBody<MemberResDto>> login(@RequestBody KakaoLoginParams params, HttpServletRequest request) {
         MemberResDto memberDto = oAuthLoginService.login(params);

--- a/src/main/java/econo/buddybridge/auth/controller/OAuthController.java
+++ b/src/main/java/econo/buddybridge/auth/controller/OAuthController.java
@@ -55,6 +55,7 @@ public class OAuthController {
     }
 
     @Operation(summary = "카카오 소셜 로그인 (코드로 로그인)", description = "Redirect URL이 백엔드 주소로 설정될 때 사용합니다.")
+    @AllowAnonymous
     @GetMapping("/login")
     public void login(@RequestParam("code") String code, HttpServletResponse response) throws IOException {
         KakaoLoginParams params = new KakaoLoginParams(code);
@@ -84,6 +85,7 @@ public class OAuthController {
 
     // 소셜로그인 with JWT
     @Operation(summary = "카카오 소셜 로그인 (JWT)", description = "JWT를 이용하여 로그인합니다.")
+    @AllowAnonymous
     @PostMapping("/login/jwt")
     public ApiResponse<CustomBody<AuthToken>> loginWithToken(@RequestBody KakaoLoginParams params) {
         AuthToken authToken = oAuthLoginService.loginWithToken(params);

--- a/src/main/java/econo/buddybridge/certification/controller/VolunteerCertificationController.java
+++ b/src/main/java/econo/buddybridge/certification/controller/VolunteerCertificationController.java
@@ -31,13 +31,12 @@ public class VolunteerCertificationController {
     private final VolunteerCertificationService volunteerCertificationService;
 
     @Operation(summary = "봉사 인증 폼 조회", description = "봉사 인증 폼을 조회합니다.")
-    @GetMapping("/{matching-id}/certifications/{certification-id}")
+    @GetMapping("/{matching-id}/certifications")
     public ApiResponse<CustomBody<VolunteerCertificationResponse>> getVolunteerCertification(
             @PathVariable("matching-id") Long matchingId,
-            @PathVariable("certification-id") Long certificationId,
             @Parameter(hidden = true) @MemberTokenId Long memberId
     ) {
-        VolunteerCertificationResponse response = volunteerCertificationService.getVolunteerCertification(matchingId, certificationId, memberId); // 왓 !!!!
+        VolunteerCertificationResponse response = volunteerCertificationService.getVolunteerCertification(matchingId, memberId); // 왓 !!!!
         return ApiResponseGenerator.success(response, HttpStatus.OK);
     }
 
@@ -53,14 +52,13 @@ public class VolunteerCertificationController {
     }
 
     @Operation(summary = "봉사활동 인증 폼 수정", description = "봉사활동 인증 폼을 수정합니다.")
-    @PutMapping("/{matching-id}/certifications/{certification-id}")
+    @PutMapping("/{matching-id}/certifications")
     public ApiResponse<CustomBody<Void>> modifyVolunteerCertification(
             @PathVariable("matching-id") Long matchingId,
-            @PathVariable("certification-id") Long certificationId,
             @Valid @RequestBody VolunteerCertificationUpdateRequest volunteerCertificationUpdateRequest,
             @Parameter(hidden = true) @MemberTokenId Long memberId
     ) {
-        volunteerCertificationService.modifyVolunteerCertification(matchingId, certificationId, volunteerCertificationUpdateRequest, memberId);
+        volunteerCertificationService.modifyVolunteerCertification(matchingId, volunteerCertificationUpdateRequest, memberId);
         return ApiResponseGenerator.success(HttpStatus.OK);
     }
 }

--- a/src/main/java/econo/buddybridge/certification/entity/VolunteerCertification.java
+++ b/src/main/java/econo/buddybridge/certification/entity/VolunteerCertification.java
@@ -47,12 +47,14 @@ public class VolunteerCertification extends BaseEntity {
     }
 
     public static VolunteerCertification of(Matching matching, VolunteerTime volunteerTime, String content) {
-        return VolunteerCertification.builder()
+        VolunteerCertification certification = VolunteerCertification.builder()
                 .matching(matching)
                 .volunteerTime(volunteerTime)
                 .content(content)
                 .isCertified(false)
                 .build();
+        matching.addVolunteerCertification(certification);
+        return certification;
     }
 
     public void updateVolunteerCertification(VolunteerTime volunteerTime, String content) {

--- a/src/main/java/econo/buddybridge/certification/entity/VolunteerCertification.java
+++ b/src/main/java/econo/buddybridge/certification/entity/VolunteerCertification.java
@@ -5,11 +5,9 @@ import econo.buddybridge.matching.entity.Matching;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -27,9 +25,6 @@ public class VolunteerCertification extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    private Matching matching;
-
     @Embedded
     private VolunteerTime volunteerTime;
 
@@ -38,8 +33,7 @@ public class VolunteerCertification extends BaseEntity {
     private boolean isCertified;
 
     @Builder
-    private VolunteerCertification(Matching matching, VolunteerTime volunteerTime, String content, boolean isCertified) {
-        this.matching = matching;
+    private VolunteerCertification(VolunteerTime volunteerTime, String content, boolean isCertified) {
         this.volunteerTime = volunteerTime;
         this.content = content;
         this.isCertified = isCertified;
@@ -47,7 +41,6 @@ public class VolunteerCertification extends BaseEntity {
 
     public static VolunteerCertification of(Matching matching, VolunteerTime volunteerTime, String content) {
         VolunteerCertification certification = VolunteerCertification.builder()
-                .matching(matching)
                 .volunteerTime(volunteerTime)
                 .content(content)
                 .isCertified(false)

--- a/src/main/java/econo/buddybridge/certification/entity/VolunteerCertification.java
+++ b/src/main/java/econo/buddybridge/certification/entity/VolunteerCertification.java
@@ -1,6 +1,5 @@
 package econo.buddybridge.certification.entity;
 
-import econo.buddybridge.certification.exception.VolunteerCertificationMatchingMismatchException;
 import econo.buddybridge.common.persistence.BaseEntity;
 import econo.buddybridge.matching.entity.Matching;
 import jakarta.persistence.Column;
@@ -60,12 +59,6 @@ public class VolunteerCertification extends BaseEntity {
     public void updateVolunteerCertification(VolunteerTime volunteerTime, String content) {
         this.volunteerTime = volunteerTime;
         this.content = content;
-    }
-
-    public void validateMatching(Matching matching) {
-        if (!this.matching.equals(matching)) {
-            throw VolunteerCertificationMatchingMismatchException.EXCEPTION;
-        }
     }
 
     public Boolean toggleCertified() {

--- a/src/main/java/econo/buddybridge/certification/repository/VolunteerCertificationCustomRepositoryImpl.java
+++ b/src/main/java/econo/buddybridge/certification/repository/VolunteerCertificationCustomRepositoryImpl.java
@@ -30,7 +30,7 @@ public class VolunteerCertificationCustomRepositoryImpl implements VolunteerCert
 
     private final JPAQueryFactory queryFactory;
 
-    @Override
+    @Override // 사용자 인증 폼 상세 조회
     public VolunteerCertificationResponse findVolunteerCertificationByMemberAndVolunteerCertification(Member member, VolunteerCertification certification) {
         return queryFactory
                 .select(new QVolunteerCertificationResponse(
@@ -45,13 +45,13 @@ public class VolunteerCertificationCustomRepositoryImpl implements VolunteerCert
                         volunteerCertification.volunteerTime.endTime,
                         volunteerCertification.content
                 ))
-                .from(volunteerCertification)
-                .leftJoin(volunteerCertification.matching, matching)
-                .where(volunteerCertification.eq(certification).and(volunteerCertification.matching.giver.eq(member)))
+                .from(matching)
+                .leftJoin(matching.volunteerCertification, volunteerCertification)
+                .where(volunteerCertification.eq(certification).and(matching.giver.eq(member)))
                 .fetchOne();
     }
 
-    @Override
+    @Override // 관리자 인증 폼 상세 조회
     public AdminVolunteerCertificationDetailResponse findAdminVolunteerCertification(VolunteerCertification certification) {
         return queryFactory
                 .select(new QAdminVolunteerCertificationDetailResponse(
@@ -88,14 +88,14 @@ public class VolunteerCertificationCustomRepositoryImpl implements VolunteerCert
                                 ),
                                 new QAdminCertificationDetailResponse(
                                         volunteerCertification.id,
-                                        volunteerCertification.matching.giver.nickname,
+                                        matching.giver.nickname,
                                         volunteerCertification.createdAt,
-                                        volunteerCertification.matching.giver.name,
-                                        volunteerCertification.matching.giver.email,
-                                        volunteerCertification.matching.post.id,
-                                        volunteerCertification.matching.post.postType,
+                                        matching.giver.name,
+                                        matching.giver.email,
+                                        matching.post.id,
+                                        matching.post.postType,
                                         volunteerCertification.volunteerTime.volunteerDate,
-                                        volunteerCertification.matching.post.assistanceType,
+                                        matching.post.assistanceType,
                                         volunteerCertification.volunteerTime.startTime,
                                         volunteerCertification.volunteerTime.endTime,
                                         volunteerCertification.content,
@@ -103,33 +103,37 @@ public class VolunteerCertificationCustomRepositoryImpl implements VolunteerCert
                                 )
                         )
                 )
-                .from(volunteerCertification)
-                .leftJoin(volunteerCertification.matching.post, post)
+                .from(matching)
+                .leftJoin(matching.volunteerCertification, volunteerCertification)
+                .leftJoin(matching.post, post)
                 .where(volunteerCertification.eq(certification))
                 .fetchOne();
     }
 
-    @Override
+    @Override // 관리자 인증 폼 전체 조회
     public VolunteerCertificationCustomPage findAdminVolunteerCertifications(Integer page, Integer size, String sort) {
         List<VolunteerCertificationListItem> content = queryFactory
                 .select(new QVolunteerCertificationListItem(
                         volunteerCertification.id,
-                        volunteerCertification.matching.giver.name,
-                        volunteerCertification.matching.giver.email,
-                        volunteerCertification.matching.post.id,
-                        volunteerCertification.matching.post.postType,
+                        matching.giver.name,
+                        matching.giver.email,
+                        matching.post.id,
+                        matching.post.postType,
                         volunteerCertification.isCertified,
                         volunteerCertification.createdAt
                 ))
-                .from(volunteerCertification)
+                .from(matching)
+                .leftJoin(matching.volunteerCertification, volunteerCertification)
+                .where(matching.volunteerCertification.isNotNull())
                 .offset((long) page * size)
                 .limit(size)
                 .orderBy(volunteerCertification.createdAt.desc())
                 .fetch();
 
         Long totalElements = queryFactory
-                .select(volunteerCertification.count())
-                .from(volunteerCertification)
+                .select(matching.volunteerCertification.count())
+                .from(matching)
+                .where(matching.volunteerCertification.isNotNull())
                 .fetchOne();
 
         long totalPage = (totalElements + size - 1) / size;

--- a/src/main/java/econo/buddybridge/certification/repository/VolunteerCertificationRepository.java
+++ b/src/main/java/econo/buddybridge/certification/repository/VolunteerCertificationRepository.java
@@ -4,6 +4,5 @@ import econo.buddybridge.certification.entity.VolunteerCertification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface VolunteerCertificationRepository extends JpaRepository<VolunteerCertification, Long>, VolunteerCertificationCustomRepository {
-
-    boolean existsByMatchingId(Long matchingId);
+    
 }

--- a/src/main/java/econo/buddybridge/certification/repository/VolunteerCertificationRepository.java
+++ b/src/main/java/econo/buddybridge/certification/repository/VolunteerCertificationRepository.java
@@ -1,15 +1,9 @@
 package econo.buddybridge.certification.repository;
 
 import econo.buddybridge.certification.entity.VolunteerCertification;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface VolunteerCertificationRepository extends JpaRepository<VolunteerCertification, Long>, VolunteerCertificationCustomRepository {
 
     boolean existsByMatchingId(Long matchingId);
-
-    @Query("SELECT vc FROM VolunteerCertification vc JOIN FETCH vc.matching m JOIN FETCH m.post  WHERE vc.id = :volunteerCertificationId")
-    Optional<VolunteerCertification> findByIdWithMatchingAndPost(@Param("volunteerCertificationId") Long volunteerCertificationId);
 }

--- a/src/main/java/econo/buddybridge/certification/service/VolunteerCertificationService.java
+++ b/src/main/java/econo/buddybridge/certification/service/VolunteerCertificationService.java
@@ -6,7 +6,6 @@ import econo.buddybridge.certification.dto.VolunteerCertificationRequest;
 import econo.buddybridge.certification.dto.VolunteerCertificationResponse;
 import econo.buddybridge.certification.dto.VolunteerCertificationUpdateRequest;
 import econo.buddybridge.certification.entity.VolunteerCertification;
-import econo.buddybridge.certification.exception.VolunteerCertificationAlreadyExistsException;
 import econo.buddybridge.certification.exception.VolunteerCertificationNotFoundException;
 import econo.buddybridge.certification.mapper.VolunteerCertificationMapper;
 import econo.buddybridge.certification.repository.VolunteerCertificationRepository;
@@ -61,15 +60,12 @@ public class VolunteerCertificationService {
     @Transactional
     public void submitVolunteerCertification(Long matchingId, VolunteerCertificationRequest request, Long memberId) {
         Member member = memberService.findMemberByIdOrThrow(memberId);
-
-        if (volunteerCertificationRepository.existsByMatchingId(matchingId)) {
-            throw VolunteerCertificationAlreadyExistsException.EXCEPTION;
-        }
-
+        
         Matching matching = matchingService.findByIdWithMembersAndPost(matchingId);
         Post post = matching.getPost();
 
         volunteerCertificationValidator.validateVolunteerCertification(matching, post, member, request);
+        matching.validateCreateVolunteerCertification();
 
         matching.handleEvent(MatchingStatusChangeEvent.SUBMIT_VOLUNTEERING_VERIFICATION, MemberRole.GIVER);
 

--- a/src/main/java/econo/buddybridge/certification/service/VolunteerCertificationService.java
+++ b/src/main/java/econo/buddybridge/certification/service/VolunteerCertificationService.java
@@ -60,12 +60,11 @@ public class VolunteerCertificationService {
     @Transactional
     public void submitVolunteerCertification(Long matchingId, VolunteerCertificationRequest request, Long memberId) {
         Member member = memberService.findMemberByIdOrThrow(memberId);
-        
+
         Matching matching = matchingService.findByIdWithMembersAndPost(matchingId);
         Post post = matching.getPost();
 
         volunteerCertificationValidator.validateVolunteerCertification(matching, post, member, request);
-        matching.validateCreateVolunteerCertification();
 
         matching.handleEvent(MatchingStatusChangeEvent.SUBMIT_VOLUNTEERING_VERIFICATION, MemberRole.GIVER);
 

--- a/src/main/java/econo/buddybridge/certification/service/VolunteerCertificationService.java
+++ b/src/main/java/econo/buddybridge/certification/service/VolunteerCertificationService.java
@@ -48,13 +48,11 @@ public class VolunteerCertificationService {
         return volunteerCertificationRepository.findAdminVolunteerCertification(volunteerCertification);
     }
 
-    @Transactional(readOnly = true)
-    public VolunteerCertificationResponse getVolunteerCertification(Long matchingId, Long certificationId, Long memberId) {
+    @Transactional(readOnly = true) // 사용자 조회
+    public VolunteerCertificationResponse getVolunteerCertification(Long matchingId, Long memberId) {
         Member member = memberService.findMemberByIdOrThrow(memberId);
-        VolunteerCertification volunteerCertification = findVolunteerCertificationByIdWithMatchingAndPost(certificationId);
         Matching matching = matchingService.findMatchingByIdOrThrow(matchingId);
-
-        volunteerCertification.validateMatching(matching);
+        VolunteerCertification volunteerCertification = matching.getVolunteerCertification();
         matching.validateVolunteerer(member);
 
         return volunteerCertificationRepository.findVolunteerCertificationByMemberAndVolunteerCertification(member, volunteerCertification);
@@ -83,11 +81,12 @@ public class VolunteerCertificationService {
     }
 
     @Transactional
-    public void modifyVolunteerCertification(Long matchingId, Long certificationId, VolunteerCertificationUpdateRequest request, Long memberId) {
-        VolunteerCertification volunteerCertification = findVolunteerCertificationByIdWithMatchingAndPost(certificationId);
+    public void modifyVolunteerCertification(Long matchingId, VolunteerCertificationUpdateRequest request, Long memberId) {
         Member author = memberService.findMemberByIdOrThrow(memberId);
         Matching matching = matchingService.findByIdWithMembersAndPost(matchingId);
         Post post = matching.getPost();
+
+        VolunteerCertification volunteerCertification = matching.getVolunteerCertification();
 
         volunteerCertificationValidator.validateVolunteerCertificationUpdate(volunteerCertification, matching, post, author, request);
 
@@ -101,12 +100,6 @@ public class VolunteerCertificationService {
     public void deleteVolunteerCertificationForAdmin(Long volunteerCertificationId) {
         VolunteerCertification volunteerCertification = findVolunteerCertificationByIdOrThrow(volunteerCertificationId);
         volunteerCertificationRepository.delete(volunteerCertification);
-    }
-
-    @Transactional(readOnly = true)
-    public VolunteerCertification findVolunteerCertificationByIdWithMatchingAndPost(Long volunteerCertificationId) {
-        return volunteerCertificationRepository.findByIdWithMatchingAndPost(volunteerCertificationId)
-                .orElseThrow(() -> VolunteerCertificationNotFoundException.EXCEPTION);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/econo/buddybridge/certification/service/VolunteerCertificationService.java
+++ b/src/main/java/econo/buddybridge/certification/service/VolunteerCertificationService.java
@@ -88,7 +88,7 @@ public class VolunteerCertificationService {
 
         VolunteerCertification volunteerCertification = matching.getVolunteerCertification();
 
-        volunteerCertificationValidator.validateVolunteerCertificationUpdate(volunteerCertification, matching, post, author, request);
+        volunteerCertificationValidator.validateVolunteerCertificationUpdate(matching, post, author, request);
 
         volunteerCertification.updateVolunteerCertification(
                 VolunteerCertificationMapper.toVolunteerTime(request),

--- a/src/main/java/econo/buddybridge/certification/validator/VolunteerCertificationValidator.java
+++ b/src/main/java/econo/buddybridge/certification/validator/VolunteerCertificationValidator.java
@@ -2,7 +2,6 @@ package econo.buddybridge.certification.validator;
 
 import econo.buddybridge.certification.dto.VolunteerCertificationRequest;
 import econo.buddybridge.certification.dto.VolunteerCertificationUpdateRequest;
-import econo.buddybridge.certification.entity.VolunteerCertification;
 import econo.buddybridge.matching.entity.Matching;
 import econo.buddybridge.member.entity.Member;
 import econo.buddybridge.post.entity.AssistanceType;
@@ -19,10 +18,7 @@ public class VolunteerCertificationValidator {
         post.validateCreateCertification(request.volunteerDate(), request.startTime(), request.endTime(), assistanceType);
     }
 
-    public void validateVolunteerCertificationUpdate(VolunteerCertification volunteerCertification, Matching matching,
-            Post post, Member member, VolunteerCertificationUpdateRequest request) {
-        volunteerCertification.validateMatching(matching);
-
+    public void validateVolunteerCertificationUpdate(Matching matching, Post post, Member member, VolunteerCertificationUpdateRequest request) {
         matching.validateUpdateVolunteerer(member);
         post.validateUpdateCertification(request.volunteerDate(), request.startTime(), request.endTime());
     }

--- a/src/main/java/econo/buddybridge/certification/validator/VolunteerCertificationValidator.java
+++ b/src/main/java/econo/buddybridge/certification/validator/VolunteerCertificationValidator.java
@@ -13,7 +13,7 @@ public class VolunteerCertificationValidator {
 
     public void validateVolunteerCertification(Matching matching, Post post, Member member, VolunteerCertificationRequest request) {
         AssistanceType assistanceType = AssistanceType.fromValue(request.assistanceType());
-
+        matching.validateCreateVolunteerCertification();
         matching.validateCreateVolunteerer(member);
         post.validateCreateCertification(request.volunteerDate(), request.startTime(), request.endTime(), assistanceType);
     }

--- a/src/main/java/econo/buddybridge/matching/entity/Matching.java
+++ b/src/main/java/econo/buddybridge/matching/entity/Matching.java
@@ -1,5 +1,6 @@
 package econo.buddybridge.matching.entity;
 
+import econo.buddybridge.certification.entity.VolunteerCertification;
 import econo.buddybridge.certification.exception.VolunteerCertificationAllowedOnlyVolunteeringCompletedException;
 import econo.buddybridge.certification.exception.VolunteerCertificationVolunteererMismatchException;
 import econo.buddybridge.chat.chatmessage.entity.ChatMessage;
@@ -72,6 +73,9 @@ public class Matching extends SoftDeletableEntity {
     @OneToMany(mappedBy = "matching", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<ChatMessage> chatMessages = new ArrayList<>();
 
+    @OneToOne(mappedBy = "matching", cascade = CascadeType.ALL, orphanRemoval = true)
+    private VolunteerCertification volunteerCertification;
+
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     private CertificationTracking certificationTracking;
 
@@ -83,6 +87,10 @@ public class Matching extends SoftDeletableEntity {
         this.matchingStatus = matchingStatus;
         this.certificationTracking = CertificationTracking.of(LocalDateTime.now().plusDays(2));
         initializeMatchingState();
+    }
+
+    public void addVolunteerCertification(VolunteerCertification volunteerCertification) {
+        this.volunteerCertification = volunteerCertification;
     }
 
     public boolean canRequestCertification() {

--- a/src/main/java/econo/buddybridge/matching/entity/Matching.java
+++ b/src/main/java/econo/buddybridge/matching/entity/Matching.java
@@ -2,6 +2,7 @@ package econo.buddybridge.matching.entity;
 
 import econo.buddybridge.certification.entity.VolunteerCertification;
 import econo.buddybridge.certification.exception.VolunteerCertificationAllowedOnlyVolunteeringCompletedException;
+import econo.buddybridge.certification.exception.VolunteerCertificationAlreadyExistsException;
 import econo.buddybridge.certification.exception.VolunteerCertificationVolunteererMismatchException;
 import econo.buddybridge.chat.chatmessage.entity.ChatMessage;
 import econo.buddybridge.chat.chatmessage.entity.MessageReadStatus;
@@ -77,7 +78,7 @@ public class Matching extends SoftDeletableEntity {
     @OneToMany(mappedBy = "matching", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<MessageReadStatus> messageReadStatuses = new ArrayList<>();
 
-    @OneToOne(mappedBy = "matching", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     private VolunteerCertification volunteerCertification;
 
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
@@ -91,6 +92,12 @@ public class Matching extends SoftDeletableEntity {
         this.matchingStatus = matchingStatus;
         this.certificationTracking = CertificationTracking.of(LocalDateTime.now().plusDays(2));
         initializeMatchingState();
+    }
+
+    public void validateCreateVolunteerCertification() {
+        if (this.volunteerCertification != null) {
+            throw VolunteerCertificationAlreadyExistsException.EXCEPTION;
+        }
     }
 
     public void addVolunteerCertification(VolunteerCertification volunteerCertification) {


### PR DESCRIPTION
## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [X] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

마이페이지 완료된 게시글 보기에선 `certification-id` 값을 가지기 애매한 상황

엔드포인트 변경을 통해 `Matching`을 기반으로 certification 조회 및 업데이트 수행 
기존 : /api/v1/matchings/{matching-id}/certifications/{certification-id}
변경 : /api/v1/matchings/{matching-id}/certifications

`Matching`을 기반으로 `VolunteerCertification`을 조회하기 위해 양방향 설정

[eaf33c6](https://github.com/JNU-econovation/BuddyBridge_BE/pull/317/commits/eaf33c6ce03362bf3b2123ffba5f92ba16b09eca) 해당 커밋으로 양방향 대신 단방향 설정 `Matching`에서 `VolunteerCertification`을 조회 하는 방식 사용

## 참고 사항

`Matching`을 기반으로 `VolunteerCertification`을 찾아가기에 

`VolunteerCertification.java`
```java
    public static VolunteerCertification of(Matching matching, VolunteerTime volunteerTime, String content) {
        VolunteerCertification certification = VolunteerCertification.builder()
                .matching(matching)
                .volunteerTime(volunteerTime)
                .content(content)
                .isCertified(false)
                .build();
        matching.addVolunteerCertification(certification);
        return certification;
    }
```
---
`Matching.java`
```java
    @OneToOne(mappedBy = "matching", cascade = CascadeType.ALL, orphanRemoval = true)
    private VolunteerCertification volunteerCertification;

    public void addVolunteerCertification(VolunteerCertification volunteerCertification) {
        this.volunteerCertification = volunteerCertification;
    }
```

VolunteerCertification이 생성되는 시점에 Matching의 VolunteerCertification 필드를 채워주는 방식을 채용했습니다.


## 관련 이슈

close #315 

## 체크리스트

- [X] 코드가 제대로 작동하는지 확인
- [X] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [X] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
