### PR TITLE
[FIX] 봉사시간 인증 완료 후 상태 변경 방지

### DIFF
--- a/src/main/java/econo/buddybridge/certification/controller/AdminVolunteerCertificationController.java
+++ b/src/main/java/econo/buddybridge/certification/controller/AdminVolunteerCertificationController.java
@@ -63,11 +63,11 @@ public class AdminVolunteerCertificationController {
 
     @Operation(summary = "인증 폼 봉사 시간 부여 여부 변경", description = "인증 폼의 봉사 시간 부여 여부를 변경합니다. 부여 완료된 경우 변경은 불가능 합니다.(true 반환 값: 봉사 시간 부여)")
     @PostMapping("/certifications/{certification-id}/toggle")
-    public ApiResponse<CustomBody<Boolean>> certify(
+    public ApiResponse<CustomBody<Void>> certify(
             @PathVariable("certification-id") Long volunteerCertificationId,
             @Parameter(hidden = true) @MemberTokenId(allowedRoles = {Role.ADMIN}) Long memberId
     ) {
-        Boolean response = volunteerCertificationService.certify(volunteerCertificationId);
-        return ApiResponseGenerator.success(response, HttpStatus.OK);
+        volunteerCertificationService.certify(volunteerCertificationId);
+        return ApiResponseGenerator.success(HttpStatus.OK);
     }
 }

--- a/src/main/java/econo/buddybridge/certification/controller/AdminVolunteerCertificationController.java
+++ b/src/main/java/econo/buddybridge/certification/controller/AdminVolunteerCertificationController.java
@@ -61,13 +61,13 @@ public class AdminVolunteerCertificationController {
         return ApiResponseGenerator.success(HttpStatus.NO_CONTENT);
     }
 
-    @Operation(summary = "인증 폼 봉사 시간 부여 여부 변경", description = "인증 폼의 봉사 시간 부여 여부를 변경합니다.(true: 봉사 시간 부여, false: 봉사 시간 미부여)")
+    @Operation(summary = "인증 폼 봉사 시간 부여 여부 변경", description = "인증 폼의 봉사 시간 부여 여부를 변경합니다. 부여 완료된 경우 변경은 불가능 합니다.(true 반환 값: 봉사 시간 부여)")
     @PostMapping("/certifications/{certification-id}/toggle")
-    public ApiResponse<CustomBody<Boolean>> toggleVolunteerCertification(
+    public ApiResponse<CustomBody<Boolean>> certify(
             @PathVariable("certification-id") Long volunteerCertificationId,
             @Parameter(hidden = true) @MemberTokenId(allowedRoles = {Role.ADMIN}) Long memberId
     ) {
-        Boolean response = volunteerCertificationService.toggleVolunteerCertification(volunteerCertificationId);
+        Boolean response = volunteerCertificationService.certify(volunteerCertificationId);
         return ApiResponseGenerator.success(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/econo/buddybridge/certification/entity/VolunteerCertification.java
+++ b/src/main/java/econo/buddybridge/certification/entity/VolunteerCertification.java
@@ -69,10 +69,10 @@ public class VolunteerCertification extends BaseEntity {
         }
     }
 
-    public Boolean certify() {
+    public void certify() {
         if (this.isCertified) {
             throw VolunteerCertificationAlreadyCertifiedException.EXCEPTION;
         }
-        return this.isCertified = true;
+        this.isCertified = true;
     }
 }

--- a/src/main/java/econo/buddybridge/certification/entity/VolunteerCertification.java
+++ b/src/main/java/econo/buddybridge/certification/entity/VolunteerCertification.java
@@ -1,5 +1,6 @@
 package econo.buddybridge.certification.entity;
 
+import econo.buddybridge.certification.exception.VolunteerCertificationAlreadyCertifiedException;
 import econo.buddybridge.certification.exception.VolunteerCertificationMatchingMismatchException;
 import econo.buddybridge.common.persistence.BaseEntity;
 import econo.buddybridge.matching.entity.Matching;
@@ -36,6 +37,8 @@ public class VolunteerCertification extends BaseEntity {
 
     private String content;
 
+    // True: 인증 완료, False: 인증 대기
+    // Default: False, 한 번 인증 완료 후 변경 불가
     private boolean isCertified;
 
     @Builder
@@ -66,8 +69,10 @@ public class VolunteerCertification extends BaseEntity {
         }
     }
 
-    public Boolean toggleCertified() {
-        this.isCertified = !this.isCertified;
-        return this.isCertified;
+    public Boolean certify() {
+        if (this.isCertified) {
+            throw VolunteerCertificationAlreadyCertifiedException.EXCEPTION;
+        }
+        return this.isCertified = true;
     }
 }

--- a/src/main/java/econo/buddybridge/certification/exception/VolunteerCertificationAlreadyCertifiedException.java
+++ b/src/main/java/econo/buddybridge/certification/exception/VolunteerCertificationAlreadyCertifiedException.java
@@ -1,0 +1,12 @@
+package econo.buddybridge.certification.exception;
+
+import econo.buddybridge.common.exception.BusinessException;
+
+public class VolunteerCertificationAlreadyCertifiedException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new VolunteerCertificationAlreadyCertifiedException();
+
+    private VolunteerCertificationAlreadyCertifiedException() {
+        super(VolunteerCertificationErrorCode.VOLUNTEER_CERTIFICATION_ALREADY_CERTIFIED);
+    }
+}

--- a/src/main/java/econo/buddybridge/certification/exception/VolunteerCertificationErrorCode.java
+++ b/src/main/java/econo/buddybridge/certification/exception/VolunteerCertificationErrorCode.java
@@ -12,6 +12,7 @@ public enum VolunteerCertificationErrorCode implements ErrorCode {
     VOLUNTEER_CERTIFICATION_ALREADY_EXISTS("VC006", HttpStatus.BAD_REQUEST, "작성한 봉사활동 인증 폼이 존재합니다."),
     VOLUNTEER_CERTIFICATION_NOT_FOUND("VC007", HttpStatus.NOT_FOUND, "봉사 인증 폼을 찾을 수 없습니다."),
     VOLUNTEER_CERTIFICATION_MATCHING_MISMATCH("VC008", HttpStatus.BAD_REQUEST, "매칭이 일치하지 않습니다. 관리자에게 문의해주세요."),
+    VOLUNTEER_CERTIFICATION_ALREADY_CERTIFIED("VC009", HttpStatus.BAD_REQUEST, "이미 인증된 봉사활동입니다. 인증 여부를 수정할 수 없습니다."),
     ;
 
     private final String code;

--- a/src/main/java/econo/buddybridge/certification/service/VolunteerCertificationService.java
+++ b/src/main/java/econo/buddybridge/certification/service/VolunteerCertificationService.java
@@ -32,9 +32,9 @@ public class VolunteerCertificationService {
     private final VolunteerCertificationValidator volunteerCertificationValidator;
 
     @Transactional
-    public Boolean certify(Long volunteerCertificationId) {
+    public void certify(Long volunteerCertificationId) {
         VolunteerCertification volunteerCertification = findVolunteerCertificationByIdOrThrow(volunteerCertificationId);
-        return volunteerCertification.certify();
+        volunteerCertification.certify();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/econo/buddybridge/certification/service/VolunteerCertificationService.java
+++ b/src/main/java/econo/buddybridge/certification/service/VolunteerCertificationService.java
@@ -32,9 +32,9 @@ public class VolunteerCertificationService {
     private final VolunteerCertificationValidator volunteerCertificationValidator;
 
     @Transactional
-    public Boolean toggleVolunteerCertification(Long volunteerCertificationId) {
+    public Boolean certify(Long volunteerCertificationId) {
         VolunteerCertification volunteerCertification = findVolunteerCertificationByIdOrThrow(volunteerCertificationId);
-        return volunteerCertification.toggleCertified();
+        return volunteerCertification.certify();
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [X] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

봉사 시간 부여 함수명을 `toggleCertified`에서 `certify`로 변경
봉사 시간 부여 완료 후 재요청 하는 경우 커스텀 비즈니스 예외 처리

## 참고 사항

https://github.com/JNU-econovation/BuddyBridge_BE/pull/317 PR과 충돌 사항이 있어 작업 중 Merge가 필요할 것으로 보입니다.

## 관련 이슈

close #305 

## 체크리스트

- [X] 코드가 제대로 작동하는지 확인
- [X] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [X] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
