### PR TITLE
[REFACTOR] Matching과 VolunteerCertification 양방향 연관관계 설정

### DIFF
--- a/src/main/java/econo/buddybridge/certification/entity/VolunteerCertification.java
+++ b/src/main/java/econo/buddybridge/certification/entity/VolunteerCertification.java
@@ -6,9 +6,12 @@ import econo.buddybridge.matching.entity.Matching;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -26,6 +29,10 @@ public class VolunteerCertification extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "matching_id")
+    private Matching matching;
+
     @Embedded
     private VolunteerTime volunteerTime;
 
@@ -36,20 +43,20 @@ public class VolunteerCertification extends BaseEntity {
     private boolean isCertified;
 
     @Builder
-    private VolunteerCertification(VolunteerTime volunteerTime, String content, boolean isCertified) {
+    private VolunteerCertification(Matching matching, VolunteerTime volunteerTime, String content, boolean isCertified) {
+        this.matching = matching;
         this.volunteerTime = volunteerTime;
         this.content = content;
         this.isCertified = isCertified;
     }
 
     public static VolunteerCertification of(Matching matching, VolunteerTime volunteerTime, String content) {
-        VolunteerCertification certification = VolunteerCertification.builder()
+        return VolunteerCertification.builder()
+                .matching(matching)
                 .volunteerTime(volunteerTime)
                 .content(content)
                 .isCertified(false)
                 .build();
-        matching.addVolunteerCertification(certification);
-        return certification;
     }
 
     public void updateVolunteerCertification(VolunteerTime volunteerTime, String content) {

--- a/src/main/java/econo/buddybridge/certification/repository/VolunteerCertificationRepositoryImpl.java
+++ b/src/main/java/econo/buddybridge/certification/repository/VolunteerCertificationRepositoryImpl.java
@@ -129,18 +129,16 @@ public class VolunteerCertificationRepositoryImpl implements VolunteerCertificat
                                 .where(blackList.reportedMember.eq(matching.giver))
                                 .exists()
                 ))
-                .from(matching)
-                .leftJoin(matching.volunteerCertification, volunteerCertification)
-                .where(matching.volunteerCertification.isNotNull())
+                .from(volunteerCertification)
+                .leftJoin(volunteerCertification.matching, matching)
                 .offset((long) page * size)
                 .limit(size)
                 .orderBy(volunteerCertification.createdAt.desc())
                 .fetch();
 
         Long totalElements = queryFactory
-                .select(matching.volunteerCertification.count())
-                .from(matching)
-                .where(matching.volunteerCertification.isNotNull())
+                .select(volunteerCertification.count())
+                .from(volunteerCertification)
                 .fetchOne();
 
         long totalPage = (totalElements + size - 1) / size;

--- a/src/main/java/econo/buddybridge/matching/entity/Matching.java
+++ b/src/main/java/econo/buddybridge/matching/entity/Matching.java
@@ -78,7 +78,7 @@ public class Matching extends SoftDeletableEntity {
     @OneToMany(mappedBy = "matching", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<MessageReadStatus> messageReadStatuses = new ArrayList<>();
 
-    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(mappedBy = "matching", cascade = CascadeType.ALL, orphanRemoval = true)
     private VolunteerCertification volunteerCertification;
 
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
@@ -98,10 +98,6 @@ public class Matching extends SoftDeletableEntity {
         if (this.volunteerCertification != null) {
             throw VolunteerCertificationAlreadyExistsException.EXCEPTION;
         }
-    }
-
-    public void addVolunteerCertification(VolunteerCertification volunteerCertification) {
-        this.volunteerCertification = volunteerCertification;
     }
 
     public boolean canVerificationRequest() {


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

- VolunteerCertification: 연관관계 주인 설정
- Matching: mappedBy 추가, 명시적 연결 함수 제거(순환 참조 오류)
- VolunteerCertificationRepositoryImpl: 양방향 관계 설정으로 isNotNull where 조건 제거, volunteerCertification 기준으로 조회

## 관련 이슈

close #339 

## 체크리스트

- [X] 코드가 제대로 작동하는지 확인
- [X] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [X] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
