### PR TITLE
[FEAT] 설문조사 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     implementation 'org.springframework.session:spring-session-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // mongodb
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
@@ -52,6 +55,11 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // Querydsl - mongodb support
+    implementation('com.querydsl:querydsl-mongodb') {
+        exclude group: 'org.mongodb', module: 'mongo-java-driver'
+    }
 
     // JWT
     compileOnly 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/src/main/java/econo/buddybridge/common/persistence/MongoBaseEntity.java
+++ b/src/main/java/econo/buddybridge/common/persistence/MongoBaseEntity.java
@@ -1,0 +1,20 @@
+package econo.buddybridge.common.persistence;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Getter
+public abstract class MongoBaseEntity {
+
+    @Field("created_at")
+    private String createdAt;
+
+    @Field("modified_at")
+    private String modifiedAt;
+
+    protected MongoBaseEntity() {
+        this.createdAt = LocalDateTime.now().toString();
+        this.modifiedAt = LocalDateTime.now().toString();
+    }
+}

--- a/src/main/java/econo/buddybridge/survey/controller/SurveyController.java
+++ b/src/main/java/econo/buddybridge/survey/controller/SurveyController.java
@@ -1,0 +1,33 @@
+package econo.buddybridge.survey.controller;
+
+import econo.buddybridge.common.annotation.AllowAnonymous;
+import econo.buddybridge.survey.service.SurveyService;
+import econo.buddybridge.utils.api.ApiResponse;
+import econo.buddybridge.utils.api.ApiResponse.CustomBody;
+import econo.buddybridge.utils.api.ApiResponseGenerator;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/surveys")
+@Tag(name = "설문조사 API", description = "설문조사 관련 API")
+public class SurveyController {
+
+    private final SurveyService surveyService;
+
+    @Operation(summary = "설문조사 생성", description = "설문조사를 생성합니다.")
+    @PostMapping
+    @AllowAnonymous
+    public ApiResponse<CustomBody<Void>> createSurvey(@RequestBody Map<String, Object> content) {
+        surveyService.save(content);
+        return ApiResponseGenerator.success(HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/econo/buddybridge/survey/entity/MongoSurvey.java
+++ b/src/main/java/econo/buddybridge/survey/entity/MongoSurvey.java
@@ -1,0 +1,32 @@
+package econo.buddybridge.survey.entity;
+
+import econo.buddybridge.common.persistence.MongoBaseEntity;
+import java.util.Map;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Document(collection = "surveys")
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MongoSurvey extends MongoBaseEntity {
+
+    @Id
+    private String id;
+
+    @Field("content")
+    private Map<String, Object> content;
+
+    public static MongoSurvey from(Map<String, Object> content) {
+        return MongoSurvey.builder()
+                .id(UUID.randomUUID().toString())
+                .content(content)
+                .build();
+    }
+}

--- a/src/main/java/econo/buddybridge/survey/repository/SurveyRepository.java
+++ b/src/main/java/econo/buddybridge/survey/repository/SurveyRepository.java
@@ -1,0 +1,8 @@
+package econo.buddybridge.survey.repository;
+
+import econo.buddybridge.survey.entity.MongoSurvey;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface SurveyRepository extends MongoRepository<MongoSurvey, String> {
+
+}

--- a/src/main/java/econo/buddybridge/survey/service/SurveyService.java
+++ b/src/main/java/econo/buddybridge/survey/service/SurveyService.java
@@ -1,0 +1,20 @@
+package econo.buddybridge.survey.service;
+
+import econo.buddybridge.survey.entity.MongoSurvey;
+import econo.buddybridge.survey.repository.SurveyRepository;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SurveyService {
+
+    private final SurveyRepository surveyRepository;
+
+    @Transactional
+    public void save(Map<String, Object> content) {
+        surveyRepository.save(MongoSurvey.from(content));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,9 @@ spring:
       password: ${REDIS_PASSWORD}
       port: ${REDIS_PORT}
 
+    mongodb:
+      uri: mongodb://${MONGO_USER}:${MONGO_PASSWORD}@${MONGO_HOST}:${MONGO_PORT}/${MONGO_DATABASE}
+
   sql:
     init:
       data-locations: classpath:data.sql

--- a/src/test/java/econo/buddybridge/survey/controller/SurveyControllerTest.java
+++ b/src/test/java/econo/buddybridge/survey/controller/SurveyControllerTest.java
@@ -1,0 +1,55 @@
+package econo.buddybridge.survey.controller;
+
+import static io.restassured.RestAssured.*;
+
+import io.restassured.RestAssured;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.annotation.Rollback;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Rollback
+@DisplayName("설문조사 API E2E 테스트")
+class SurveyControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("설문지 저장")
+    void saveSurvey() {
+        //given
+        Map<String, Object> content = new HashMap<>(Map.of(
+                "title", "설문조사 제목",
+                "description", "설문조사 설명",
+                "firstQuestion", "첫번째 질문",
+                "firstAnswer", "첫번째 답변",
+                "secondQuestion", "두번째 질문",
+                "secondAnswer", "두번째 답변"
+        ));
+
+        content.put("title", null); // 값이 null인 경우도 저장되어야 함
+
+        //when
+        given()
+                .port(port)
+                .contentType("application/json")
+                .body(content)
+                .log().all()    // 요청 로그 출력
+                .when()
+                .post("/api/v1/surveys")
+                .then()
+                .statusCode(201)
+                .log().all();   // 응답 로그 출력
+    }
+}

--- a/src/test/java/econo/buddybridge/survey/repository/SurveyRepositoryTest.java
+++ b/src/test/java/econo/buddybridge/survey/repository/SurveyRepositoryTest.java
@@ -1,0 +1,36 @@
+package econo.buddybridge.survey.repository;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import econo.buddybridge.survey.entity.MongoSurvey;
+import java.util.HashMap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("MongoFormRepository 테스트")
+class SurveyRepositoryTest {
+
+    @Autowired
+    private SurveyRepository surveyRepository;
+
+    @Test
+    @DisplayName("저장 및 삭제 테스트")
+    void deleteTest() {
+        //given
+        HashMap<String, Object> content = new HashMap<>();
+        content.put("test", "test");
+        content.put("test2", "test2");
+
+        MongoSurvey mongoSurvey = MongoSurvey.from(content);
+
+        //when
+        surveyRepository.save(mongoSurvey);
+        surveyRepository.deleteById(mongoSurvey.getId());
+
+        //then
+        assertNull(surveyRepository.findById(mongoSurvey.getId()).orElse(null));
+    }
+}


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

설문조사 API 구현 - 설문지 저장

## 참고 사항

- 클라이언트 측에서 원하는 형태로 데이터를 저장할 수 있도록 구현했습니다.
- 요청 예시
```
Request URI:	/api/v1/surveys

Headers:	Accept=*/*
		Content-Type=application/json

Body:
{
    "secondAnswer": "두번째 답변",
    "description": "설문조사 설명",
    "firstQuestion": "첫번째 질문",
    "title": null,
    "secondQuestion": "두번째 질문",
    "firstAnswer": "첫번째 답변"
}
```

- 응답 예시
```
HTTP/1.1 201 
Content-Type: application/json

{
    "success": true,
    "data": null,
    "error": null
}
```

- 저장된 값 예시
```mongo
{
  _id: '3b089aca-1a55-4cb6-85e2-29fd5b0f9eb5',
  content: {
    secondAnswer: '두번째 답변',
    description: '설문조사 설명',
    firstQuestion: '첫번째 질문',
    secondQuestion: '두번째 질문',
    title: null,
    firstAnswer: '첫번째 답변'
  },
  created_at: '2025-01-21T18:20:45.717398',
  modified_at: '2025-01-21T18:20:45.717414',
  _class: 'econo.buddybridge.survey.entity.MongoSurvey'
}
```

## 관련 이슈

close #347 

## 체크리스트

- [x] 코드가 제대로 작동하는지 확인
- [x] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [x] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
