### PR TITLE
[FEAT] Report 생성/삭제 시 신고 횟수에 따른 자동 블랙리스트 등록/해제 기능

### DIFF
--- a/src/main/java/econo/buddybridge/report/event/ReportCreatedEvent.java
+++ b/src/main/java/econo/buddybridge/report/event/ReportCreatedEvent.java
@@ -1,0 +1,19 @@
+package econo.buddybridge.report.event;
+
+import econo.buddybridge.common.event.DomainEvent;
+import econo.buddybridge.member.entity.Member;
+import econo.buddybridge.report.entity.Report;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReportCreatedEvent extends DomainEvent {
+
+    private final Member reportedMember;
+
+    public static ReportCreatedEvent from(Report report) {
+        return new ReportCreatedEvent(report.getReported());
+    }
+}

--- a/src/main/java/econo/buddybridge/report/event/ReportDeletedEvent.java
+++ b/src/main/java/econo/buddybridge/report/event/ReportDeletedEvent.java
@@ -1,0 +1,18 @@
+package econo.buddybridge.report.event;
+
+import econo.buddybridge.member.entity.Member;
+import econo.buddybridge.report.entity.Report;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReportDeletedEvent {
+
+    private final Member reportedMember;
+
+    public static ReportDeletedEvent from(Report report) {
+        return new ReportDeletedEvent(report.getReported());
+    }
+}

--- a/src/main/java/econo/buddybridge/report/event/handler/ReportCreatedEventHandler.java
+++ b/src/main/java/econo/buddybridge/report/event/handler/ReportCreatedEventHandler.java
@@ -1,0 +1,37 @@
+package econo.buddybridge.report.event.handler;
+
+import econo.buddybridge.blacklist.entity.BlackList;
+import econo.buddybridge.blacklist.repository.BlackListRepository;
+import econo.buddybridge.member.entity.Member;
+import econo.buddybridge.report.event.ReportCreatedEvent;
+import econo.buddybridge.report.repository.ReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ReportCreatedEventHandler {
+
+    private static final int BLACK_LIST_REPORT_THRESHOLD = 3;
+
+    private final ReportRepository reportRepository;
+    private final BlackListRepository blackListRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleReportCreatedEvent(ReportCreatedEvent event) {
+        Member reportedMember = event.getReportedMember();
+
+        if (blackListRepository.existsByReportedMember(reportedMember)) {
+            return;
+        }
+
+        if (reportRepository.totalReportsByReported(reportedMember) >= BLACK_LIST_REPORT_THRESHOLD) {
+            BlackList blackList = BlackList.builder()
+                    .reportedMember(reportedMember)
+                    .build();
+            blackListRepository.save(blackList);
+        }
+    }
+}

--- a/src/main/java/econo/buddybridge/report/event/handler/ReportCreatedEventHandler.java
+++ b/src/main/java/econo/buddybridge/report/event/handler/ReportCreatedEventHandler.java
@@ -7,7 +7,8 @@ import econo.buddybridge.report.event.ReportCreatedEvent;
 import econo.buddybridge.report.repository.ReportRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
@@ -19,7 +20,8 @@ public class ReportCreatedEventHandler {
     private final ReportRepository reportRepository;
     private final BlackListRepository blackListRepository;
 
-    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleReportCreatedEvent(ReportCreatedEvent event) {
         Member reportedMember = event.getReportedMember();
 

--- a/src/main/java/econo/buddybridge/report/event/handler/ReportDeletedEventHandler.java
+++ b/src/main/java/econo/buddybridge/report/event/handler/ReportDeletedEventHandler.java
@@ -1,0 +1,35 @@
+package econo.buddybridge.report.event.handler;
+
+import econo.buddybridge.blacklist.repository.BlackListRepository;
+import econo.buddybridge.member.entity.Member;
+import econo.buddybridge.report.event.ReportDeletedEvent;
+import econo.buddybridge.report.repository.ReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ReportDeletedEventHandler {
+
+    private static final int BLACK_LIST_REPORT_THRESHOLD = 3;
+
+    private final ReportRepository reportRepository;
+    private final BlackListRepository blackListRepository;
+
+    @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleReportDeletedEvent(ReportDeletedEvent event) {
+        Member reportedMember = event.getReportedMember();
+
+        if (!blackListRepository.existsByReportedMember(reportedMember)) {
+            return;
+        }
+
+        if (reportRepository.totalReportsByReported(reportedMember) < BLACK_LIST_REPORT_THRESHOLD) {
+            blackListRepository.deleteByReportedMember(reportedMember);
+        }
+    }
+}

--- a/src/main/java/econo/buddybridge/report/repository/ReportRepositoryCustom.java
+++ b/src/main/java/econo/buddybridge/report/repository/ReportRepositoryCustom.java
@@ -1,5 +1,6 @@
 package econo.buddybridge.report.repository;
 
+import econo.buddybridge.member.entity.Member;
 import econo.buddybridge.report.entity.CommentReport;
 import econo.buddybridge.report.entity.MatchingReport;
 import econo.buddybridge.report.entity.PostReport;
@@ -23,4 +24,6 @@ public interface ReportRepositoryCustom {
     Long totalCommentReports();
 
     Long totalMatchingReports();
+
+    Long totalReportsByReported(Member reported);
 }

--- a/src/main/java/econo/buddybridge/report/repository/ReportRepositoryImpl.java
+++ b/src/main/java/econo/buddybridge/report/repository/ReportRepositoryImpl.java
@@ -6,6 +6,7 @@ import static econo.buddybridge.report.entity.QPostReport.postReport;
 import static econo.buddybridge.report.entity.QReport.report;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import econo.buddybridge.member.entity.Member;
 import econo.buddybridge.report.entity.CommentReport;
 import econo.buddybridge.report.entity.MatchingReport;
 import econo.buddybridge.report.entity.PostReport;
@@ -87,6 +88,15 @@ public class ReportRepositoryImpl implements ReportRepositoryCustom {
         return queryFactory
                 .select(matchingReport.count())
                 .from(matchingReport)
+                .fetchOne();
+    }
+
+    @Override
+    public Long totalReportsByReported(Member reported) {
+        return queryFactory
+                .select(report.count())
+                .from(report)
+                .where(report.reported.eq(reported))
                 .fetchOne();
     }
 }

--- a/src/main/java/econo/buddybridge/report/service/CommentReportService.java
+++ b/src/main/java/econo/buddybridge/report/service/CommentReportService.java
@@ -10,10 +10,12 @@ import econo.buddybridge.post.service.PostService;
 import econo.buddybridge.report.dto.ReportRequest;
 import econo.buddybridge.report.dto.ReportedCommentWithPostResponse;
 import econo.buddybridge.report.entity.CommentReport;
+import econo.buddybridge.report.event.ReportCreatedEvent;
 import econo.buddybridge.report.exception.ReportCommentAlreadyExistsException;
 import econo.buddybridge.report.exception.ReportNotFoundException;
 import econo.buddybridge.report.repository.CommentReportRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +27,7 @@ public class CommentReportService {
     private final CommentService commentService;
     private final MemberService memberService;
     private final PostService postService;
+    private final ApplicationEventPublisher publisher;
 
     @Transactional
     public void reportComment(Long commentId, ReportRequest reportRequest, Long memberId) {
@@ -35,12 +38,15 @@ public class CommentReportService {
             throw ReportCommentAlreadyExistsException.EXCEPTION;
         }
 
-        commentReportRepository.save(CommentReport.of(
+        CommentReport report = CommentReport.of(
                 comment,
                 member,
                 reportRequest.reportType(),
                 reportRequest.reportReason()
-        ));
+        );
+        commentReportRepository.save(report);
+        
+        publisher.publishEvent(ReportCreatedEvent.from(report));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/econo/buddybridge/report/service/MatchingReportService.java
+++ b/src/main/java/econo/buddybridge/report/service/MatchingReportService.java
@@ -8,10 +8,12 @@ import econo.buddybridge.member.entity.Member;
 import econo.buddybridge.member.service.MemberService;
 import econo.buddybridge.report.dto.ReportRequest;
 import econo.buddybridge.report.entity.MatchingReport;
+import econo.buddybridge.report.event.ReportCreatedEvent;
 import econo.buddybridge.report.exception.ReportMatchingAlreadyExistsException;
 import econo.buddybridge.report.exception.ReportNotFoundException;
 import econo.buddybridge.report.repository.MatchingReportRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +25,7 @@ public class MatchingReportService {
     private final MatchingService matchingService;
     private final MatchingRoomService matchingRoomService;
     private final MemberService memberService;
+    private final ApplicationEventPublisher publisher;
 
     @Transactional
     public void reportMatching(Long matchingId, ReportRequest reportRequest, Long memberId) {
@@ -33,12 +36,15 @@ public class MatchingReportService {
             throw ReportMatchingAlreadyExistsException.EXCEPTION;
         }
 
-        matchingReportRepository.save(MatchingReport.of(
+        MatchingReport report = MatchingReport.of(
                 matching,
                 member,
                 reportRequest.reportType(),
                 reportRequest.reportReason()
-        ));
+        );
+        matchingReportRepository.save(report);
+
+        publisher.publishEvent(ReportCreatedEvent.from(report));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/econo/buddybridge/report/service/PostReportService.java
+++ b/src/main/java/econo/buddybridge/report/service/PostReportService.java
@@ -7,10 +7,12 @@ import econo.buddybridge.post.entity.Post;
 import econo.buddybridge.post.service.PostService;
 import econo.buddybridge.report.dto.ReportRequest;
 import econo.buddybridge.report.entity.PostReport;
+import econo.buddybridge.report.event.ReportCreatedEvent;
 import econo.buddybridge.report.exception.ReportNotFoundException;
 import econo.buddybridge.report.exception.ReportPostAlreadyExistsException;
 import econo.buddybridge.report.repository.PostReportRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +23,7 @@ public class PostReportService {
     private final PostReportRepository postReportRepository;
     private final PostService postService;
     private final MemberService memberService;
+    private final ApplicationEventPublisher publisher;
 
     @Transactional
     public void reportPost(Long postId, ReportRequest reportRequest, Long memberId) {
@@ -31,12 +34,15 @@ public class PostReportService {
             throw ReportPostAlreadyExistsException.EXCEPTION;
         }
 
-        postReportRepository.save(PostReport.of(
+        PostReport report = PostReport.of(
                 post,
                 member,
                 reportRequest.reportType(),
                 reportRequest.reportReason()
-        ));
+        );
+        postReportRepository.save(report);
+        
+        publisher.publishEvent(ReportCreatedEvent.from(report));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/econo/buddybridge/report/service/ReportService.java
+++ b/src/main/java/econo/buddybridge/report/service/ReportService.java
@@ -11,10 +11,12 @@ import econo.buddybridge.report.entity.CommentReport;
 import econo.buddybridge.report.entity.MatchingReport;
 import econo.buddybridge.report.entity.PostReport;
 import econo.buddybridge.report.entity.Report;
+import econo.buddybridge.report.event.ReportDeletedEvent;
 import econo.buddybridge.report.exception.ReportNotFoundException;
 import econo.buddybridge.report.repository.ReportRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +26,7 @@ public class ReportService {
 
     private final BlackListService blackListService;
     private final ReportRepository reportRepository;
+    private final ApplicationEventPublisher publisher;
 
     @Transactional(readOnly = true)
     public ReportDetailResponse getReport(Long reportId) {
@@ -75,6 +78,8 @@ public class ReportService {
     public void deleteReport(Long reportId) {
         Report report = findReportByIdOrThrow(reportId);
         reportRepository.delete(report);
+
+        publisher.publishEvent(ReportDeletedEvent.from(report));
     }
 
     private Report findReportByIdOrThrow(Long reportId) {


### PR DESCRIPTION
## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

신고 대상자의 신고 갯수를 카운트

신고 시 갯수를 카운트해 3개 이상이면 블랙리스트 등록
삭제 시 갯수를 카운트해 3개 미만이면 블랙리스트에서 제거

## 참고 사항

`Report` 대신 `ReportedMember`로 도메인 이벤트 발행
- `BlackList`에 등록하기 위해선 `Report`의 많은 정보보다는 신고 대상자에 대한 정보만 필요

`Transactional(propagation = Propagation.REQUIRES_NEW)` 적용
- `phase`를 default 값인 `AFTER_COMMIT`을 준 후 새로 `Transaction` 생성
- 블랙리스트 등록 및 삭제가 이루어지지 않아도 신고는 접수되고 삭제되어야 한다 생각했어요.

## 관련 이슈

close #349 

## 체크리스트

- [X] 코드가 제대로 작동하는지 확인
- [X] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [X] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
