### PR TITLE
[REFACTOR] 마이페이지 찜한 게시글 totalElements에 postStatus 필터링 추가

### DIFF
--- a/src/main/java/econo/buddybridge/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/econo/buddybridge/post/repository/PostRepositoryImpl.java
@@ -159,7 +159,10 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         List<Post> posts = queryFactory
                 .select(postLike.post)
                 .from(postLike)
-                .where(postLike.member.id.eq(memberId), buildPostTypeExpression(postType, postLike.post))
+                .where(
+                        postLike.member.id.eq(memberId),
+                        buildPostTypeExpression(postType, postLike.post)
+                )
                 .offset((long) page * size)
                 .orderBy(buildOrderSpecifier(sort, postLike.post))
                 .fetch();
@@ -169,7 +172,10 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         Long totalElements = queryFactory
                 .select(postLike.count())
                 .from(postLike)
-                .where(postLike.member.id.eq(memberId))
+                .where(
+                        postLike.member.id.eq(memberId),
+                        buildPostTypeExpression(postType, postLike.post)
+                )
                 .fetchOne();
 
         long totalPage = (totalElements + size - 1) / size;


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 (아래에 상세 내용 기입)

## 변경 사항 요약

마이페이지의 찜한 게시글 조회 API 개선

기존 : 찜한 게시글 조회 시 단순 전체 게시글 수만 반환

개선 : 사용자 유형(Giver/Taker)에 따라 구분된 totalElements 값 반환, Giver의 찜한 게시글 수와 Taker의 찜한 게시글 수를 분리하여 제공

## 관련 이슈

close #351 

## 체크리스트

- [X] 코드가 제대로 작동하는지 확인
- [X] 테스트가 추가되었거나 기존 테스트가 통과하는지 확인
- [X] 관련 문서(ERD, API 문서 등)가 업데이트되었는지 확인
